### PR TITLE
Update transformers dependency version to 4.57.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ description = "dLLM: Simple Diffusion Language Modeling"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "transformers==4.57.0",
+    "transformers==4.57.1",
     "accelerate==1.11.0",
     "deepspeed==0.18.0",
     "peft==0.17.1",


### PR DESCRIPTION
- transformers v4.57.0 has been yanked and it throws a warning everytime we install dllm. 
- I've tested inference, train and eval with 4.57.1 and nothing breaks