### PR TITLE
Suggestion: Use DataCollatorForLanguageModeling in bert/pt.py

### DIFF
--- a/examples/bert/pt.py
+++ b/examples/bert/pt.py
@@ -110,10 +110,11 @@ def train():
         train_dataset=dataset["train"],
         eval_dataset=dataset.get("test", None),
         args=training_args,
-        data_collator=transformers.DataCollatorForSeq2Seq(
-            tokenizer,
+        data_collator=transformers.DataCollatorForLanguageModeling(
+            tokenizer=tokenizer,
+            mlm=True,
+            mlm_probability=0.15,  # Standart value TODO: Make this configurable
             return_tensors="pt",
-            padding=True,
         ),
     )
     trainer.train()


### PR DESCRIPTION
Hi there,

Thanks for maintaining this great project!

I was running the [`examples/bert/pt.py`](https://github.com/ZHZisZZ/dllm/blob/main/examples/bert/pt.py) script and got a bit confused. This PR swaps `transformers.DataCollatorForSeq2Seq` with `transformers.DataCollatorForLanguageModeling` (with `mlm=True`).

My thinking was that `DataCollatorForSeq2Seq` is for encoder-decoder models, whereas BERT pre-training is an MLM task that fits `DataCollatorForLanguageModeling` better.

I'm **not entirely sure** if this is correct and it's very possible I'm missing something, but I wanted to propose the change just in case.

Happy to discuss this, and my apologies if I'm mistaken. Please feel free to close this PR if it's not needed!

Cheers!