### PR TITLE
Fix: Padded prompt in bd3lm generation IDs

### DIFF
--- a/dllm/core/samplers/bd3lm.py
+++ b/dllm/core/samplers/bd3lm.py
@@ -442,6 +442,9 @@ class BD3LMSampler(BaseSampler):
 
             generated += cur_block_len
 
+        # remove padded prompt prefix
+        x = x[:, padded_prompt_len:]
+
         # ==========================================================
         # 4) Output
         # ==========================================================

--- a/dllm/pipelines/a2d/eval.py
+++ b/dllm/pipelines/a2d/eval.py
@@ -198,7 +198,7 @@ class BD3LMEvalHarness(LM):
                 right_shift_logits=self.right_shift_logits,
             )
             generated_answer = self.tokenizer.decode(
-                generated_ids[0][prompt[0].shape[0] :], skip_special_tokens=False
+                generated_ids[0], skip_special_tokens=False
             )
             for stop_seq in stop_tokens:
                 if stop_seq in generated_answer:


### PR DESCRIPTION
Running with: 

```bash
NUM_GPU=4
MODEL=dllm-collection/Qwen3-0.6B-diffusion-bd3lm-v0.1
accelerate launch --num_processes $NUM_GPU \
    dllm/pipelines/a2d/eval.py \
    --tasks "gsm8k_cot" \
    --model "bd3lm" \
    --apply_chat_template \
    --num_fewshot 0 \
    --model_args "pretrained=${MODEL},max_new_tokens=256,steps=256,block_size=32,cfg=0.0,temperature=0.0" \
    --write_out \
    --log_samples \
    --output_path "gsm8k_cot_results"
```

The results are:

```bash
bd3lm (pretrained=dllm-collection/Qwen3-0.6B-diffusion-bd3lm-v0.1,max_new_tokens=256,steps=256,block_size=32,cfg=0.0), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: 1
|  Tasks  |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|---------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k_cot|      3|flexible-extract|     5|exact_match|↑  |0.0629|±  |0.0067|
|         |       |strict-match    |     5|exact_match|↑  |0.0553|±  |0.0063|
```
This does not match [the reported results](https://github.com/ZHZisZZ/dllm/tree/main/examples/a2d#evaluation-results). This is because the generated ids include the _padded prompts_:

<img width="1388" height="830" alt="image" src="https://github.com/user-attachments/assets/49aaf590-16a7-4d0a-b98b-0849e97ffc72" />

After slicing off the first prompt[0].shape[0] tokens from the generated ids, the end of the prompt is still included in the generated ids. Since the prompt ends with `"<|im_end|>"`, which is one of the stop tokens, after splitting on stop tokens,  the final generated answer only includes the last `n` tokens in the prompt, where `n` is the difference between the length of the padded prompt and the unpadded prompt:

<img width="817" height="710" alt="image" src="https://github.com/user-attachments/assets/6da9f0a4-971e-43eb-8c98-931c6e75aeb2" />

After applying this fix, the results are:

```bash
bd3lm (pretrained=dllm-collection/Qwen3-0.6B-diffusion-bd3lm-v0.1,max_new_tokens=256,steps=256,block_size=32,cfg=0.0,temperature=0.0), gen_kwargs: (None), limit: None, num_fewshot: 0, batch_size: 8
|  Tasks  |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|---------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k_cot|      3|flexible-extract|     0|exact_match|↑  |0.4845|±  |0.0138|
|         |       |strict-match    |     0|exact_match|↑  |0.0008|±  |0.0008|

```