### PR TITLE
fix: replace bare excepts with specific exception types

### DIFF
--- a/assets/logo.py
+++ b/assets/logo.py
@@ -26,7 +26,7 @@ def load_font_auto_size(text, w, h, target_width_ratio=0.95, target_height_ratio
             font = ImageFont.truetype(
                 "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", size=mid
             )
-        except:
+        except OSError:
             font = ImageFont.load_default()
         dummy = Image.new("L", (w, h), 0)
         d = ImageDraw.Draw(dummy)

--- a/dllm/pipelines/dream/models/generation_utils.py
+++ b/dllm/pipelines/dream/models/generation_utils.py
@@ -69,7 +69,7 @@ def sample_tokens(logits, temperature=0.0, top_p=None, top_k=None, margin_confid
         try:
             x0 = dists.Categorical(probs=probs).sample()
             confidence = torch.gather(probs, -1, x0.unsqueeze(-1)).squeeze(-1)
-        except:
+        except Exception:
             confidence, x0 = probs.max(dim=-1)
     else:
         confidence, x0 = probs.max(dim=-1)

--- a/dllm/pipelines/fastdllm/llada/models/modeling_llada.py
+++ b/dllm/pipelines/fastdllm/llada/models/modeling_llada.py
@@ -42,7 +42,7 @@ try:
     from torch.nn.attention.flex_attention import flex_attention, create_block_mask
 
     FLEX_ATTN_AVAILABLE = True
-except:
+except ImportError:
     FLEX_ATTN_AVAILABLE = False
 import torch
 import torch.backends.cuda


### PR DESCRIPTION
Replace bare `except:` with specific exception types across 3 files.

**Changes:**
- `assets/logo.py`: `except:` → `except OSError:` (font file not found fallback)
- `dllm/pipelines/dream/models/generation_utils.py`: `except:` → `except Exception:` (categorical sampling fallback)
- `dllm/pipelines/fastdllm/llada/models/modeling_llada.py`: `except:` → `except ImportError:` (flex_attention import guard)

**Why:** Bare `except:` catches `BaseException` including `KeyboardInterrupt` and `SystemExit`. Using specific types preserves the intended fallback behavior while allowing system exceptions to propagate.