### PR TITLE
Add validated Info-Gain sampler support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,4 +136,5 @@ dmypy.json
 /.data/
 /wandb/
 /.logs/
+/run-logs/
 /.models/

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Simple Diffusion Language Modeling
 
 **[2026/02] ⚡[`Fast-dLLM`](https://github.com/NVlabs/Fast-dLLM)**: We support accelerated inference and evaluation of  [LLaDA](https://arxiv.org/abs/2502.09992) and [Dream](https://arxiv.org/abs/2508.15487) with [Fast-dLLM](https://arxiv.org/abs/2505.22618) (cache, confidence-threshold decoding). See [`examples/fastdllm`](/examples/fastdllm) for inference / evaluation instructions.
 
+**[2026/05] 📈[`Information-Gain-Sampler`](https://github.com/yks23/Information-Gain-Sampler)**: We support [Info-Gain decoding](https://arxiv.org/abs/2602.18176) (*Improving Sampling for Masked Diffusion Models via Information Gain*, **ICML 2026**) for [LLaDA](https://arxiv.org/abs/2502.09992) and [Dream](https://arxiv.org/abs/2508.15487) alongside Fast-dLLM-style KV cache on LLaDA. See [`examples/infogain`](/examples/infogain).
+
 **[2025/12] 🤗[`Tiny-A2D`](https://huggingface.co/collections/dllm-hub/tiny-a2d)**: We released a collection of **SOTA** small (0.5B/0.6B) diffusion models adapted from AR models, with fully open recipes for converting **ANY** AR model (e.g., Qwen, LLaMA, and GPT-2) into a diffusion model. See [`examples/a2d`](/examples/a2d) for training / inference / evaluation instructions.
 
 **[2025/11] 🤗[`BERT-Chat`](https://huggingface.co/collections/dllm-hub/bert-chat)**: We released a collection of BERTs finetuned to chat with diffusion, with open recipes for turning **ANY** BERT encoder (e.g., BERT, RoBERTa, ModernBERT) into a diffusion model. See [`examples/bert`](/examples/bert) for training / inference / evaluation instructions.
@@ -88,6 +90,7 @@ Simple Diffusion Language Modeling
 
    </details> -->
 - [`examples/fastdllm`](/examples/fastdllm): Inferencing and evaluating [LLaDA](https://arxiv.org/abs/2502.09992) and [Dream](https://arxiv.org/abs/2508.15487) with [Fast-dLLM](https://arxiv.org/abs/2505.22618) (cache, confidence-threshold decoding, and beyond).
+- [`examples/infogain`](/examples/infogain): Inferencing and evaluating LLaDA and Dream with [Information-Gain sampling](https://arxiv.org/abs/2602.18176) (**ICML 2026**; see [upstream repo](https://github.com/yks23/Information-Gain-Sampler)).
 - [`examples/rl`](/examples/rl): [GRPO](https://github.com/dllm-reasoning/d1) training for [LLaDA](https://arxiv.org/abs/2502.09992) and [Tiny-A2D](https://huggingface.co/collections/dllm-hub/tiny-a2d) diffusion language models across reasoning tasks (GSM8K, MATH, Countdown, Sudoku, Code).
 - More upcoming.
 
@@ -146,6 +149,7 @@ dllm
 │   ├── dream
 │   ├── editflow
 │   ├── fastdllm
+│   ├── infogain
 │   ├── llada
 │   │   ├── models         # Model architecture and configs 
 │   │   ├── sampler.py     # Inference module
@@ -164,6 +168,7 @@ examples
 ├── dream
 ├── editflow
 ├── fastdllm
+├── infogain
 ├── llada
 │   ├── chat.py            # Interactive inference example
 │   ├── sample.py          # Inference example
@@ -322,6 +327,12 @@ You can accelerate inference of [LLaDA](https://arxiv.org/abs/2502.09992) and [D
 python examples/fastdllm/llada/sample.py --model_name_or_path "GSAI-ML/LLaDA-8B-Instruct" --use_cache prefix --threshold 0.9
 ```
 
+You can run [Information-Gain](https://arxiv.org/abs/2602.18176) sampling via [`examples/infogain`](/examples/infogain):
+```shell
+python examples/infogain/llada/sample.py --model_name_or_path "GSAI-ML/LLaDA-8B-Instruct" --use_cache none --threshold 0.8 --candidate_number 8
+python examples/infogain/dream/sample.py --model_name_or_path "Dream-org/Dream-v0-Instruct-7B" --use_cache none --alg info_gain --threshold 0.8
+```
+
 <p align="center">
     <img src="/assets/chat.gif" alt="chat" width="80%">
 </p>
@@ -352,6 +363,12 @@ We provide scripts to evaluate [LLaDA](https://arxiv.org/abs/2502.09992) and [Dr
 ```shell
 bash examples/fastdllm/llada/eval.sh --model_name_or_path "GSAI-ML/LLaDA-8B-Instruct" --instruct True --num_gpu 1
 bash examples/fastdllm/dream/eval.sh --model_name_or_path "Dream-org/Dream-v0-Base-7B" --instruct False --num_gpu 1
+```
+
+Scripts for [Information-Gain](https://arxiv.org/abs/2602.18176) evaluation:
+```shell
+bash examples/infogain/llada/eval.sh --model_name_or_path "GSAI-ML/LLaDA-8B-Instruct" --instruct True --num_gpu 1
+bash examples/infogain/dream/eval.sh --model_name_or_path "Dream-org/Dream-v0-Base-7B" --instruct False --num_gpu 1
 ```
 
 

--- a/dllm/__init__.py
+++ b/dllm/__init__.py
@@ -1,3 +1,24 @@
-from . import core, data, pipelines, utils
+"""
+Top-level dllm package with lazy submodule loading.
+
+Run import check:
+    python -c "import dllm; print(dllm.__all__)"
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
 
 __all__ = ["core", "data", "pipelines", "utils"]
+
+
+def __getattr__(name: str):
+    if name in __all__:
+        module = import_module(f"{__name__}.{name}")
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(list(globals().keys()) + __all__)

--- a/dllm/core/__init__.py
+++ b/dllm/core/__init__.py
@@ -1,3 +1,24 @@
-from . import eval, samplers, schedulers, trainers
+"""
+Core namespace with lazy submodule loading.
+
+Run import check:
+    python -c "import dllm.core; print(dllm.core.__all__)"
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
 
 __all__ = ["eval", "samplers", "schedulers", "trainers"]
+
+
+def __getattr__(name: str):
+    if name in __all__:
+        module = import_module(f"{__name__}.{name}")
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(list(globals().keys()) + __all__)

--- a/dllm/pipelines/__init__.py
+++ b/dllm/pipelines/__init__.py
@@ -1,3 +1,14 @@
-from . import a2d, bert, dream, editflow, fastdllm, llada, llada2, llada21, rl
+from . import a2d, bert, dream, editflow, fastdllm, infogain, llada, llada2, llada21, rl
 
-__all__ = ["a2d", "bert", "dream", "editflow", "fastdllm", "llada", "llada2", "llada21", "rl"]
+__all__ = [
+    "a2d",
+    "bert",
+    "dream",
+    "editflow",
+    "fastdllm",
+    "infogain",
+    "llada",
+    "llada2",
+    "llada21",
+    "rl",
+]

--- a/dllm/pipelines/__init__.py
+++ b/dllm/pipelines/__init__.py
@@ -1,4 +1,14 @@
-from . import a2d, bert, dream, editflow, fastdllm, infogain, llada, llada2, llada21, rl
+"""
+Pipeline namespace with lazy submodule loading.
+
+This keeps `dllm.pipelines.fastdllm` / `dllm.pipelines.infogain` style access
+working without importing every optional pipeline dependency at package import
+time.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
 
 __all__ = [
     "a2d",
@@ -12,3 +22,15 @@ __all__ = [
     "llada21",
     "rl",
 ]
+
+
+def __getattr__(name: str):
+    if name in __all__:
+        module = import_module(f"{__name__}.{name}")
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(list(globals().keys()) + __all__)

--- a/dllm/pipelines/dream/__init__.py
+++ b/dllm/pipelines/dream/__init__.py
@@ -1,10 +1,13 @@
-from . import utils
-from .models.configuration_dream import DreamConfig
-from .models.modeling_dream import DreamModel
-from .models.tokenization_dream import DreamTokenizer
-from .sampler import DreamSampler, DreamSamplerConfig
-from .trainer import DreamTrainer
-from . import utils
+"""
+Dream pipeline namespace with lazy submodule loading.
+
+Run import check:
+    python -c "import dllm.pipelines.dream as dream; print(dream.__all__)"
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
 
 __all__ = [
     "DreamConfig",
@@ -15,3 +18,33 @@ __all__ = [
     "DreamTrainer",
     "utils",
 ]
+
+
+def __getattr__(name: str):
+    if name == "utils":
+        module = import_module(f"{__name__}.utils")
+        globals()[name] = module
+        return module
+    if name == "DreamConfig":
+        module = import_module(f"{__name__}.models.configuration_dream")
+        value = module.DreamConfig
+    elif name == "DreamModel":
+        module = import_module(f"{__name__}.models.modeling_dream")
+        value = module.DreamModel
+    elif name == "DreamTokenizer":
+        module = import_module(f"{__name__}.models.tokenization_dream")
+        value = module.DreamTokenizer
+    elif name in ("DreamSampler", "DreamSamplerConfig"):
+        module = import_module(f"{__name__}.sampler")
+        value = getattr(module, name)
+    elif name == "DreamTrainer":
+        module = import_module(f"{__name__}.trainer")
+        value = module.DreamTrainer
+    else:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(list(globals().keys()) + __all__)

--- a/dllm/pipelines/fastdllm/__init__.py
+++ b/dllm/pipelines/fastdllm/__init__.py
@@ -1,7 +1,24 @@
 """
-Fast-dLLM pipelines: dream and llada.
+Fast-dLLM pipeline namespace with lazy submodule loading.
+
+Run import check:
+    python -c "import dllm.pipelines.fastdllm as fastdllm; print(fastdllm.__all__)"
 """
 
-from . import dream, llada
+from __future__ import annotations
+
+from importlib import import_module
 
 __all__ = ["dream", "llada"]
+
+
+def __getattr__(name: str):
+    if name in __all__:
+        module = import_module(f"{__name__}.{name}")
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(list(globals().keys()) + __all__)

--- a/dllm/pipelines/infogain/__init__.py
+++ b/dllm/pipelines/infogain/__init__.py
@@ -1,0 +1,9 @@
+"""
+Info-Gain masked diffusion sampling (LLaDA + Dream).
+
+Upstream reference: https://github.com/yks23/Information-Gain-Sampler
+"""
+
+from . import dream, llada
+
+__all__ = ["dream", "llada"]

--- a/dllm/pipelines/infogain/__init__.py
+++ b/dllm/pipelines/infogain/__init__.py
@@ -2,8 +2,25 @@
 Info-Gain masked diffusion sampling (LLaDA + Dream).
 
 Upstream reference: https://github.com/yks23/Information-Gain-Sampler
+
+Run import check:
+    python -c "import dllm.pipelines.infogain as ig; print(ig.__all__)"
 """
 
-from . import dream, llada
+from __future__ import annotations
+
+from importlib import import_module
 
 __all__ = ["dream", "llada"]
+
+
+def __getattr__(name: str):
+    if name in __all__:
+        module = import_module(f"{__name__}.{name}")
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(list(globals().keys()) + __all__)

--- a/dllm/pipelines/infogain/dream/__init__.py
+++ b/dllm/pipelines/infogain/dream/__init__.py
@@ -1,16 +1,13 @@
-"""Info-Gain Dream pipeline."""
+"""
+Info-Gain Dream pipeline.
 
-from .models import InfoGainDreamConfig, InfoGainDreamModel
-from .sampler import InfoGainDreamSampler, InfoGainDreamSamplerConfig
+Run import check:
+    python -c "from dllm.pipelines.infogain.dream import InfoGainDreamSampler"
+"""
 
-try:
-    from transformers import AutoConfig, AutoModel, AutoModelForMaskedLM
+from __future__ import annotations
 
-    AutoConfig.register("infogain_dream", InfoGainDreamConfig)
-    AutoModel.register(InfoGainDreamConfig, InfoGainDreamModel)
-    AutoModelForMaskedLM.register(InfoGainDreamConfig, InfoGainDreamModel)
-except ImportError:
-    pass
+from importlib import import_module
 
 __all__ = [
     "InfoGainDreamConfig",
@@ -18,3 +15,45 @@ __all__ = [
     "InfoGainDreamSampler",
     "InfoGainDreamSamplerConfig",
 ]
+
+
+def _register_model_classes(config_cls, model_cls) -> None:
+    try:
+        from transformers import AutoConfig, AutoModel, AutoModelForMaskedLM
+
+        AutoConfig.register("infogain_dream", config_cls)
+        AutoModel.register(config_cls, model_cls)
+        AutoModelForMaskedLM.register(config_cls, model_cls)
+    except (ImportError, ValueError):
+        pass
+
+
+def _load_models():
+    module = import_module(f"{__name__}.models")
+    config_cls = module.InfoGainDreamConfig
+    model_cls = module.InfoGainDreamModel
+    _register_model_classes(config_cls, model_cls)
+    globals()["InfoGainDreamConfig"] = config_cls
+    globals()["InfoGainDreamModel"] = model_cls
+    return module
+
+
+def _load_sampler():
+    module = import_module(f"{__name__}.sampler")
+    globals()["InfoGainDreamSampler"] = module.InfoGainDreamSampler
+    globals()["InfoGainDreamSamplerConfig"] = module.InfoGainDreamSamplerConfig
+    return module
+
+
+def __getattr__(name: str):
+    if name in ("InfoGainDreamConfig", "InfoGainDreamModel"):
+        _load_models()
+        return globals()[name]
+    if name in ("InfoGainDreamSampler", "InfoGainDreamSamplerConfig"):
+        _load_sampler()
+        return globals()[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(list(globals().keys()) + __all__)

--- a/dllm/pipelines/infogain/dream/__init__.py
+++ b/dllm/pipelines/infogain/dream/__init__.py
@@ -1,0 +1,20 @@
+"""Info-Gain Dream pipeline."""
+
+from .models import InfoGainDreamConfig, InfoGainDreamModel
+from .sampler import InfoGainDreamSampler, InfoGainDreamSamplerConfig
+
+try:
+    from transformers import AutoConfig, AutoModel, AutoModelForMaskedLM
+
+    AutoConfig.register("infogain_dream", InfoGainDreamConfig)
+    AutoModel.register(InfoGainDreamConfig, InfoGainDreamModel)
+    AutoModelForMaskedLM.register(InfoGainDreamConfig, InfoGainDreamModel)
+except ImportError:
+    pass
+
+__all__ = [
+    "InfoGainDreamConfig",
+    "InfoGainDreamModel",
+    "InfoGainDreamSampler",
+    "InfoGainDreamSamplerConfig",
+]

--- a/dllm/pipelines/infogain/dream/eval.py
+++ b/dllm/pipelines/infogain/dream/eval.py
@@ -1,0 +1,60 @@
+"""
+accelerate launch --num_processes 4 \\
+    dllm/pipelines/infogain/dream/eval.py \\
+    --tasks gsm8k \\
+    --model infogain_dream \\
+    --apply_chat_template \\
+    --num_fewshot 5 \\
+    --model_args "pretrained=Dream-org/Dream-v0-Instruct-7B,max_new_tokens=256,steps=256,alg=info_gain,threshold=0.8,candidate_number=8,dtype=bfloat16,add_bos_token=True"
+"""
+
+from dataclasses import dataclass
+
+from lm_eval.__main__ import cli_evaluate
+from lm_eval.api.registry import register_model
+
+from dllm.pipelines.dream.eval import DreamEvalConfig, DreamEvalHarness
+from dllm.pipelines.infogain.dream import (
+    InfoGainDreamConfig,
+    InfoGainDreamSampler,
+    InfoGainDreamSamplerConfig,
+)
+
+
+@dataclass
+class InfoGainDreamEvalSamplerConfig(InfoGainDreamSamplerConfig):
+    max_new_tokens: int = 128
+    steps: int = 128
+    temperature: float = 0.0
+    top_p: float | None = None
+    top_k: int | None = None
+    alg: str = "info_gain"
+
+
+@dataclass
+class InfoGainDreamEvalConfig(DreamEvalConfig):
+    def get_model_config(self, pretrained: str):
+        return InfoGainDreamConfig.from_pretrained(pretrained)
+
+
+@register_model("infogain_dream")
+class InfoGainDreamEvalHarness(DreamEvalHarness):
+    def __init__(
+        self,
+        eval_config: InfoGainDreamEvalConfig | None = None,
+        sampler_config: InfoGainDreamSamplerConfig | None = None,
+        sampler_cls: type[InfoGainDreamSampler] = InfoGainDreamSampler,
+        **kwargs,
+    ) -> None:
+        eval_config = eval_config or InfoGainDreamEvalConfig()
+        sampler_config = sampler_config or InfoGainDreamEvalSamplerConfig()
+        super().__init__(
+            eval_config=eval_config,
+            sampler_config=sampler_config,
+            sampler_cls=sampler_cls,
+            **kwargs,
+        )
+
+
+if __name__ == "__main__":
+    cli_evaluate()

--- a/dllm/pipelines/infogain/dream/models/__init__.py
+++ b/dllm/pipelines/infogain/dream/models/__init__.py
@@ -1,0 +1,6 @@
+"""Info-Gain Dream model registration."""
+
+from .configuration_dream import InfoGainDreamConfig
+from .modeling_dream import InfoGainDreamModel
+
+__all__ = ["InfoGainDreamConfig", "InfoGainDreamModel"]

--- a/dllm/pipelines/infogain/dream/models/configuration_dream.py
+++ b/dllm/pipelines/infogain/dream/models/configuration_dream.py
@@ -1,0 +1,16 @@
+"""
+Dream Info-Gain configuration wrapper.
+
+Run (from repo root): python -c "from dllm.pipelines.infogain.dream.models import InfoGainDreamConfig; print(InfoGainDreamConfig)"
+"""
+
+from dllm.pipelines.dream.models.configuration_dream import DreamConfig
+
+
+class InfoGainDreamConfig(DreamConfig):
+    """Thin wrapper with a distinct ``model_type`` for HuggingFace auto-registration."""
+
+    model_type = "infogain_dream"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)

--- a/dllm/pipelines/infogain/dream/models/modeling_dream.py
+++ b/dllm/pipelines/infogain/dream/models/modeling_dream.py
@@ -17,7 +17,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""PyTorch Info-Gain Dream model (same weights as Dream; distinct ``model_type``)."""
+"""
+PyTorch Info-Gain Dream model (same weights as Dream; distinct ``model_type``).
+
+Run compile check:
+    python -m py_compile dllm/pipelines/infogain/dream/models/modeling_dream.py
+"""
 
 import math
 from typing import List, Optional, Tuple, Union
@@ -464,6 +469,17 @@ class InfoGainDreamSdpaAttention(InfoGainDreamAttention):
         dual_cache: Optional[bool] = False,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
         if output_attentions:
+            if (
+                use_cache
+                or past_key_value is not None
+                or dual_cache
+                or replace_position is not None
+            ):
+                raise ValueError(
+                    "output_attentions=True is not supported together with "
+                    "InfoGainDream cache decoding. Disable output_attentions or "
+                    "set use_cache=False."
+                )
             # TODO: Improve this warning with e.g. `model.config.attn_implementation = "manual"` once this is implemented.
             logger.warning_once(
                 "InfoGainDreamModel is using InfoGainDreamSdpaAttention, but `torch.nn.functional.scaled_dot_product_attention` does not support `output_attentions=True`. Falling back to the manual attention implementation, "
@@ -476,6 +492,8 @@ class InfoGainDreamSdpaAttention(InfoGainDreamAttention):
                 past_key_value=past_key_value,
                 output_attentions=output_attentions,
                 use_cache=use_cache,
+                cache_position=cache_position,
+                position_embeddings=position_embeddings,
             )
 
         bsz, q_len, _ = hidden_states.size()
@@ -484,15 +502,44 @@ class InfoGainDreamSdpaAttention(InfoGainDreamAttention):
         key_states = self.k_proj(hidden_states)
         value_states = self.v_proj(hidden_states)
 
+        block_end_index = None
         if past_key_value is not None:
             if dual_cache:
+                if replace_position is None:
+                    raise ValueError(
+                        "replace_position must be provided when dual_cache=True."
+                    )
+                if replace_position.dim() != 2:
+                    raise ValueError(
+                        "replace_position must have shape [batch, sequence_length], "
+                        f"got {tuple(replace_position.shape)}"
+                    )
+                if replace_position.shape[0] != bsz:
+                    raise ValueError(
+                        "replace_position batch size must match hidden_states: "
+                        f"{replace_position.shape[0]} != {bsz}"
+                    )
                 past_key, past_value = past_key_value
-                replace_indices = replace_position.nonzero(as_tuple=True)[1]
-                past_key[:, replace_indices] = key_states
+                selected_counts = replace_position.sum(dim=1)
+                if not torch.all(selected_counts == q_len):
+                    raise ValueError(
+                        "Each batch row in replace_position must select exactly "
+                        f"{q_len} positions; got {selected_counts.tolist()}."
+                    )
+                for batch_idx in range(bsz):
+                    replace_indices = replace_position[batch_idx].nonzero(
+                        as_tuple=True
+                    )[0]
+                    past_key[batch_idx, replace_indices] = key_states[batch_idx]
+                    past_value[batch_idx, replace_indices] = value_states[batch_idx]
+                block_end_index = int(
+                    replace_position.nonzero(as_tuple=True)[1].max().item() + 1
+                )
                 key_states = past_key
-                past_value[:, replace_indices] = value_states
                 value_states = past_value
             else:
+                if replace_position is not None:
+                    raise ValueError("replace_position requires dual_cache=True.")
                 past_key, past_value = past_key_value
                 key_states = torch.cat([past_key, key_states], dim=-2)
                 value_states = torch.cat([past_value, value_states], dim=-2)
@@ -520,13 +567,13 @@ class InfoGainDreamSdpaAttention(InfoGainDreamAttention):
         else:
             cos, sin = position_embeddings
 
-        if dual_cache:
+        if block_end_index is not None:
             query_states, key_states = apply_rotary_pos_emb(
                 query_states,
                 key_states,
                 cos,
                 sin,
-                block_end_index=replace_indices.max() + 1,
+                block_end_index=block_end_index,
             )
         else:
             query_states, key_states = apply_rotary_pos_emb(
@@ -825,6 +872,22 @@ class InfoGainDreamBaseModel(InfoGainDreamPreTrainedModel):
                 )
                 use_cache = False
 
+        if output_attentions and (
+            use_cache
+            or past_key_values is not None
+            or dual_cache
+            or replace_position is not None
+        ):
+            raise ValueError(
+                "output_attentions=True is not supported together with "
+                "InfoGainDream cache decoding. Disable output_attentions or "
+                "set use_cache=False."
+            )
+        if replace_position is not None and not dual_cache:
+            raise ValueError("replace_position requires dual_cache=True.")
+        if past_key_values is not None and len(past_key_values) == 0:
+            raise ValueError("past_key_values must be None or a non-empty layer list.")
+
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
 
@@ -898,7 +961,7 @@ class InfoGainDreamBaseModel(InfoGainDreamPreTrainedModel):
             if output_attentions:
                 all_self_attns += (layer_outputs[1],)
             if use_cache:
-                attn_key_values.append(layer_outputs[1])
+                attn_key_values.append(layer_outputs[-1])
 
         hidden_states = self.norm(hidden_states)
 

--- a/dllm/pipelines/infogain/dream/models/modeling_dream.py
+++ b/dllm/pipelines/infogain/dream/models/modeling_dream.py
@@ -923,7 +923,7 @@ class InfoGainDreamBaseModel(InfoGainDreamPreTrainedModel):
 class InfoGainDreamModel(DreamGenerationMixin, InfoGainDreamPreTrainedModel):
     _tied_weights_keys = ["lm_head.weight"]
 
-    def __init__(self, config):
+    def __init__(self, config, **kwargs):
         super().__init__(config)
         self.model = InfoGainDreamBaseModel(config)
         self.vocab_size = config.vocab_size

--- a/dllm/pipelines/infogain/dream/models/modeling_dream.py
+++ b/dllm/pipelines/infogain/dream/models/modeling_dream.py
@@ -1,0 +1,1056 @@
+# coding=utf-8
+# Copyright 2024 The Dream team, HKUNLP Group and the HuggingFace Inc. team. All rights reserved.
+#
+# This code is based on EleutherAI's GPT-NeoX library and the GPT-NeoX
+# and OPT and Qwen implementations in this library. It has been modified from its
+# original forms to accommodate minor architectural differences compared
+# to GPT-NeoX and OPT and Qwen used by the Meta AI and Qwen team that trained the model.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""PyTorch Info-Gain Dream model (same weights as Dream; distinct ``model_type``)."""
+
+import math
+from typing import List, Optional, Tuple, Union
+import os
+import torch
+import torch.utils.checkpoint
+from torch import nn
+
+from transformers.activations import ACT2FN
+from transformers.cache_utils import Cache, DynamicCache
+from transformers.modeling_outputs import (
+    BaseModelOutput,
+    MaskedLMOutput,
+)
+from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
+from transformers.modeling_utils import PreTrainedModel
+from transformers.utils import (
+    add_start_docstrings,
+    add_start_docstrings_to_model_forward,
+    is_flash_attn_2_available,
+    is_flash_attn_greater_or_equal_2_10,
+    logging,
+)
+from transformers import PretrainedConfig
+from .configuration_dream import InfoGainDreamConfig
+from dllm.pipelines.dream.models.generation_utils import (
+    DreamGenerationMixin,
+    DreamGenerationConfig,
+)
+
+if is_flash_attn_2_available():
+    from transformers.modeling_flash_attention_utils import _flash_attention_forward
+
+
+logger = logging.get_logger(__name__)
+
+
+_CHECKPOINT_FOR_DOC = "Dream-7B"
+_CONFIG_FOR_DOC = "InfoGainDreamConfig"
+
+
+class BaseModelOutputWithPast(BaseModelOutput):
+    def __init__(
+        self,
+        last_hidden_state: torch.FloatTensor,
+        hidden_states: Optional[Tuple[torch.FloatTensor]] = None,
+        attentions: Optional[Tuple[torch.FloatTensor]] = None,
+        past_key_values: Optional[Tuple[torch.FloatTensor]] = None,
+    ):
+        super().__init__(last_hidden_state, hidden_states, attentions)
+        self.past_key_values = past_key_values
+
+
+class MaskedLMOutputWithPastKeyValues(MaskedLMOutput):
+    def __init__(
+        self,
+        past_key_values: Optional[List[Tuple[torch.Tensor, torch.Tensor]]] = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.past_key_values = past_key_values
+
+
+# Copied from transformers.models.llama.modeling_llama.LlamaRMSNorm with Llama->InfoGainDream
+class InfoGainDreamRMSNorm(nn.Module):
+    def __init__(self, hidden_size, eps=1e-6):
+        """
+        InfoGainDreamRMSNorm is equivalent to T5LayerNorm
+        """
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states):
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * hidden_states.to(input_dtype)
+
+    def extra_repr(self):
+        return f"{tuple(self.weight.shape)}, eps={self.variance_epsilon}"
+
+
+# Copied from transformers.models.llama.modeling_llama.LlamaRotaryEmbedding with Llama->InfoGainDream
+class InfoGainDreamRotaryEmbedding(nn.Module):
+    def __init__(
+        self,
+        dim=None,
+        max_position_embeddings=2048,
+        base=10000,
+        device=None,
+        scaling_factor=1.0,
+        rope_type="default",
+        config: Optional[InfoGainDreamConfig] = None,
+    ):
+        super().__init__()
+        # TODO (joao): remove the `if` below, only used for BC
+        self.rope_kwargs = {}
+        if config is None:
+            logger.warning_once(
+                "`InfoGainDreamRotaryEmbedding` can now be fully parameterized by passing the model config through the "
+                "`config` argument. All other arguments will be removed in v4.46"
+            )
+            self.rope_kwargs = {
+                "rope_type": rope_type,
+                "factor": scaling_factor,
+                "dim": dim,
+                "base": base,
+                "max_position_embeddings": max_position_embeddings,
+            }
+            self.rope_type = rope_type
+            self.max_seq_len_cached = max_position_embeddings
+            self.original_max_seq_len = max_position_embeddings
+        else:
+            # BC: "rope_type" was originally "type"
+            if config.rope_scaling is not None:
+                self.rope_type = config.rope_scaling.get(
+                    "rope_type", config.rope_scaling.get("type")
+                )
+            else:
+                self.rope_type = "default"
+            self.max_seq_len_cached = config.max_position_embeddings
+            self.original_max_seq_len = config.max_position_embeddings
+
+        self.config = config
+        self.rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+
+        inv_freq, self.attention_scaling = self.rope_init_fn(
+            self.config, device, **self.rope_kwargs
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self.original_inv_freq = self.inv_freq
+
+    def reset_parameters(self):
+        inv_freq, self.attention_scaling = self.rope_init_fn(
+            self.config, self.inv_freq.device, **self.rope_kwargs
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self.original_inv_freq = self.inv_freq
+
+    def _dynamic_frequency_update(self, position_ids, device):
+        """
+        dynamic RoPE layers should recompute `inv_freq` in the following situations:
+        1 - growing beyond the cached sequence length (allow scaling)
+        2 - the current sequence length is in the original scale (avoid losing precision with small sequences)
+        """
+        seq_len = torch.max(position_ids) + 1
+        if seq_len > self.max_seq_len_cached:  # growth
+            inv_freq, self.attention_scaling = self.rope_init_fn(
+                self.config, device, seq_len=seq_len, **self.rope_kwargs
+            )
+            self.register_buffer(
+                "inv_freq", inv_freq, persistent=False
+            )  # TODO joao: may break with compilation
+            self.max_seq_len_cached = seq_len
+
+        if (
+            seq_len < self.original_max_seq_len
+            and self.max_seq_len_cached > self.original_max_seq_len
+        ):  # reset
+            self.register_buffer("inv_freq", self.original_inv_freq, persistent=False)
+            self.max_seq_len_cached = self.original_max_seq_len
+
+    @torch.no_grad()
+    def forward(self, x, position_ids):
+        if "dynamic" in self.rope_type:
+            self._dynamic_frequency_update(position_ids, device=x.device)
+
+        # Core RoPE block
+        inv_freq_expanded = (
+            self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1)
+        )
+        position_ids_expanded = position_ids[:, None, :].float()
+        # Force float32 (see https://github.com/huggingface/transformers/pull/29285)
+        device_type = x.device.type
+        device_type = (
+            device_type
+            if isinstance(device_type, str) and device_type != "mps"
+            else "cpu"
+        )
+        with torch.autocast(device_type=device_type, enabled=False):
+            freqs = (
+                inv_freq_expanded.float() @ position_ids_expanded.float()
+            ).transpose(1, 2)
+            emb = torch.cat((freqs, freqs), dim=-1)
+            cos = emb.cos()
+            sin = emb.sin()
+
+        # Advanced RoPE types (e.g. yarn) apply a post-processing scaling factor, equivalent to scaling attention
+        cos = cos * self.attention_scaling
+        sin = sin * self.attention_scaling
+
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+
+# Copied from transformers.models.llama.modeling_llama.rotate_half
+def rotate_half(x):
+    """Rotates half the hidden dims of the input."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+# Copied from transformers.models.llama.modeling_llama.apply_rotary_pos_emb
+def apply_rotary_pos_emb(
+    q,
+    k,
+    cos,
+    sin,
+    position_ids=None,
+    unsqueeze_dim=1,
+    block_end_index: Optional[torch.Tensor] = None,
+):
+    """Applies Rotary Position Embedding to the query and key tensors.
+
+    Args:
+        q (`torch.Tensor`): The query tensor.
+        k (`torch.Tensor`): The key tensor.
+        cos (`torch.Tensor`): The cosine part of the rotary embedding.
+        sin (`torch.Tensor`): The sine part of the rotary embedding.
+        position_ids (`torch.Tensor`, *optional*):
+            Deprecated and unused.
+        unsqueeze_dim (`int`, *optional*, defaults to 1):
+            The 'unsqueeze_dim' argument specifies the dimension along which to unsqueeze cos[position_ids] and
+            sin[position_ids] so that they can be properly broadcasted to the dimensions of q and k. For example, note
+            that cos[position_ids] and sin[position_ids] have the shape [batch_size, seq_len, head_dim]. Then, if q and
+            k have the shape [batch_size, heads, seq_len, head_dim], then setting unsqueeze_dim=1 makes
+            cos[position_ids] and sin[position_ids] broadcastable to the shapes of q and k. Similarly, if q and k have
+            the shape [batch_size, seq_len, heads, head_dim], then set unsqueeze_dim=2.
+    Returns:
+        `tuple(torch.Tensor)` comprising of the query and key tensors rotated using the Rotary Position Embedding.
+    """
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+
+    query_len, key_len = q.shape[-2], k.shape[-2]
+
+    if block_end_index is None:
+        q_embed = (q * cos[:, :, key_len - query_len : key_len, :]) + (
+            rotate_half(q) * sin[:, :, key_len - query_len : key_len, :]
+        )
+    else:
+        start = (block_end_index - query_len).to(dtype=torch.long)
+        idx = torch.arange(query_len, device=q.device, dtype=torch.long) + start
+        cos_slice = cos.index_select(2, idx)
+        sin_slice = sin.index_select(2, idx)
+        q_embed = (q * cos_slice) + (rotate_half(q) * sin_slice)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+
+    return q_embed, k_embed
+
+
+# Copied from transformers.models.mistral.modeling_mistral.MistralMLP with Mistral->InfoGainDream
+class InfoGainDreamMLP(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.intermediate_size
+        self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
+        self.act_fn = ACT2FN[config.hidden_act]
+
+    def forward(self, hidden_state):
+        return self.down_proj(
+            self.act_fn(self.gate_proj(hidden_state)) * self.up_proj(hidden_state)
+        )
+
+
+# Copied from transformers.models.llama.modeling_llama.repeat_kv
+def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
+    """
+    This is the equivalent of torch.repeat_interleave(x, dim=1, repeats=n_rep). The hidden states go from (batch,
+    num_key_value_heads, seqlen, head_dim) to (batch, num_attention_heads, seqlen, head_dim)
+    """
+    batch, num_key_value_heads, slen, head_dim = hidden_states.shape
+    if n_rep == 1:
+        return hidden_states
+    hidden_states = hidden_states[:, :, None, :, :].expand(
+        batch, num_key_value_heads, n_rep, slen, head_dim
+    )
+    return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
+
+
+class InfoGainDreamAttention(nn.Module):
+    """
+    Multi-headed attention from 'Attention Is All You Need' paper. Modified to use sliding window attention: Longformer
+    and "Generating Long Sequences with Sparse Transformers".
+    """
+
+    def __init__(self, config: InfoGainDreamConfig, layer_idx: Optional[int] = None):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        if layer_idx is None:
+            logger.warning_once(
+                f"Instantiating {self.__class__.__name__} without passing `layer_idx` is not recommended and will "
+                "to errors during the forward call, if caching is used. Please make sure to provide a `layer_idx` "
+                "when creating this class."
+            )
+
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_dim = self.hidden_size // self.num_heads
+        self.num_key_value_heads = config.num_key_value_heads
+        self.num_key_value_groups = self.num_heads // self.num_key_value_heads
+        self.max_position_embeddings = config.max_position_embeddings
+        self.rope_theta = config.rope_theta
+        self.is_causal = False
+        self.attention_dropout = config.attention_dropout
+
+        if (self.head_dim * self.num_heads) != self.hidden_size:
+            raise ValueError(
+                f"hidden_size must be divisible by num_heads (got `hidden_size`: {self.hidden_size}"
+                f" and `num_heads`: {self.num_heads})."
+            )
+        self.q_proj = nn.Linear(
+            self.hidden_size, self.num_heads * self.head_dim, bias=True
+        )
+        self.k_proj = nn.Linear(
+            self.hidden_size, self.num_key_value_heads * self.head_dim, bias=True
+        )
+        self.v_proj = nn.Linear(
+            self.hidden_size, self.num_key_value_heads * self.head_dim, bias=True
+        )
+        self.o_proj = nn.Linear(
+            self.num_heads * self.head_dim, self.hidden_size, bias=False
+        )
+
+        self.rotary_emb = InfoGainDreamRotaryEmbedding(config=self.config)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_value: Optional[Cache] = None,
+        output_attentions: bool = False,
+        use_cache: bool = False,
+        cache_position: Optional[torch.LongTensor] = None,
+        position_embeddings: Optional[
+            Tuple[torch.Tensor, torch.Tensor]
+        ] = None,  # will become mandatory in v4.46
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
+        bsz, q_len, _ = hidden_states.size()
+
+        query_states = self.q_proj(hidden_states)
+        key_states = self.k_proj(hidden_states)
+        value_states = self.v_proj(hidden_states)
+
+        query_states = query_states.view(
+            bsz, q_len, self.num_heads, self.head_dim
+        ).transpose(1, 2)
+        key_states = key_states.view(
+            bsz, q_len, self.num_key_value_heads, self.head_dim
+        ).transpose(1, 2)
+        value_states = value_states.view(
+            bsz, q_len, self.num_key_value_heads, self.head_dim
+        ).transpose(1, 2)
+
+        if position_embeddings is None:
+            logger.warning_once(
+                "The attention layers in this model are transitioning from computing the RoPE embeddings internally "
+                "through `position_ids` (2D tensor with the indexes of the tokens), to using externally computed "
+                "`position_embeddings` (Tuple of tensors, containing cos and sin). In v4.46 `position_ids` will be "
+                "removed and `position_embeddings` will be mandatory."
+            )
+            cos, sin = self.rotary_emb(value_states, position_ids)
+        else:
+            cos, sin = position_embeddings
+        query_states, key_states = apply_rotary_pos_emb(
+            query_states, key_states, cos, sin
+        )
+
+        if past_key_value is not None:
+            cache_kwargs = {
+                "sin": sin,
+                "cos": cos,
+                "cache_position": cache_position,
+            }  # Specific to RoPE models
+            key_states, value_states = past_key_value.update(
+                key_states, value_states, self.layer_idx, cache_kwargs
+            )
+
+        # repeat k/v heads if n_kv_heads < n_heads
+        key_states = repeat_kv(key_states, self.num_key_value_groups)
+        value_states = repeat_kv(value_states, self.num_key_value_groups)
+
+        attn_weights = torch.matmul(
+            query_states, key_states.transpose(2, 3)
+        ) / math.sqrt(self.head_dim)
+        if attention_mask is not None:  # no matter the length, we just slice it
+            causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
+            attn_weights = attn_weights + causal_mask
+
+        # upcast attention to fp32
+        attn_weights = nn.functional.softmax(
+            attn_weights, dim=-1, dtype=torch.float32
+        ).to(query_states.dtype)
+        attn_weights = nn.functional.dropout(
+            attn_weights, p=self.attention_dropout, training=self.training
+        )
+        attn_output = torch.matmul(attn_weights, value_states)
+
+        if attn_output.size() != (bsz, self.num_heads, q_len, self.head_dim):
+            raise ValueError(
+                f"`attn_output` should be of size {(bsz, self.num_heads, q_len, self.head_dim)}, but is"
+                f" {attn_output.size()}"
+            )
+
+        attn_output = attn_output.transpose(1, 2).contiguous()
+        attn_output = attn_output.reshape(bsz, q_len, self.hidden_size)
+
+        attn_output = self.o_proj(attn_output)
+
+        if not output_attentions:
+            attn_weights = None
+
+        return attn_output, attn_weights, past_key_value
+
+
+class InfoGainDreamSdpaAttention(InfoGainDreamAttention):
+    """
+    InfoGainDream attention module using torch.nn.functional.scaled_dot_product_attention. This module inherits from
+    `InfoGainDreamAttention` as the weights of the module stays untouched. The only changes are on the forward pass to adapt to
+    SDPA API.
+    """
+
+    # Adapted from InfoGainDreamAttention.forward
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_value: Optional[Cache] = None,
+        output_attentions: bool = False,
+        use_cache: bool = False,
+        cache_position: Optional[torch.LongTensor] = None,
+        position_embeddings: Optional[
+            Tuple[torch.Tensor, torch.Tensor]
+        ] = None,  # will become mandatory in v4.46
+        replace_position: Optional[torch.Tensor] = None,
+        dual_cache: Optional[bool] = False,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
+        if output_attentions:
+            # TODO: Improve this warning with e.g. `model.config.attn_implementation = "manual"` once this is implemented.
+            logger.warning_once(
+                "InfoGainDreamModel is using InfoGainDreamSdpaAttention, but `torch.nn.functional.scaled_dot_product_attention` does not support `output_attentions=True`. Falling back to the manual attention implementation, "
+                'but specifying the manual implementation will be required from Transformers version v5.0.0 onwards. This warning can be removed using the argument `attn_implementation="eager"` when loading the model.'
+            )
+            return super().forward(
+                hidden_states=hidden_states,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_value=past_key_value,
+                output_attentions=output_attentions,
+                use_cache=use_cache,
+            )
+
+        bsz, q_len, _ = hidden_states.size()
+
+        query_states = self.q_proj(hidden_states)
+        key_states = self.k_proj(hidden_states)
+        value_states = self.v_proj(hidden_states)
+
+        if past_key_value is not None:
+            if dual_cache:
+                past_key, past_value = past_key_value
+                replace_indices = replace_position.nonzero(as_tuple=True)[1]
+                past_key[:, replace_indices] = key_states
+                key_states = past_key
+                past_value[:, replace_indices] = value_states
+                value_states = past_value
+            else:
+                past_key, past_value = past_key_value
+                key_states = torch.cat([past_key, key_states], dim=-2)
+                value_states = torch.cat([past_value, value_states], dim=-2)
+
+        past_key_value = (key_states, value_states) if use_cache else None
+
+        query_states = query_states.view(
+            bsz, q_len, self.num_heads, self.head_dim
+        ).transpose(1, 2)
+        key_states = key_states.view(
+            bsz, -1, self.num_key_value_heads, self.head_dim
+        ).transpose(1, 2)
+        value_states = value_states.view(
+            bsz, -1, self.num_key_value_heads, self.head_dim
+        ).transpose(1, 2)
+
+        if position_embeddings is None:
+            logger.warning_once(
+                "The attention layers in this model are transitioning from computing the RoPE embeddings internally "
+                "through `position_ids` (2D tensor with the indexes of the tokens), to using externally computed "
+                "`position_embeddings` (Tuple of tensors, containing cos and sin). In v4.46 `position_ids` will be "
+                "removed and `position_embeddings` will be mandatory."
+            )
+            cos, sin = self.rotary_emb(value_states, position_ids)
+        else:
+            cos, sin = position_embeddings
+
+        if dual_cache:
+            query_states, key_states = apply_rotary_pos_emb(
+                query_states,
+                key_states,
+                cos,
+                sin,
+                block_end_index=replace_indices.max() + 1,
+            )
+        else:
+            query_states, key_states = apply_rotary_pos_emb(
+                query_states, key_states, cos, sin
+            )
+
+        key_states = repeat_kv(key_states, self.num_key_value_groups)
+        value_states = repeat_kv(value_states, self.num_key_value_groups)
+
+        # causal_mask = attention_mask
+        # if attention_mask is not None:  # no matter the length, we just slice it
+        #     causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
+
+        # SDPA with memory-efficient backend is currently (torch==2.1.2) bugged with non-contiguous inputs with custom attn_mask,
+        # Reference: https://github.com/pytorch/pytorch/issues/112577.
+        if query_states.device.type == "cuda" and attention_mask is not None:
+            query_states = query_states.contiguous()
+            key_states = key_states.contiguous()
+            value_states = value_states.contiguous()
+
+        # We dispatch to SDPA's Flash Attention or Efficient kernels via this `is_causal` if statement instead of an inline conditional assignment
+        # in SDPA to support both torch.compile's dynamic shapes and full graph options. An inline conditional prevents dynamic shapes from compiling.
+        # The q_len > 1 is necessary to match with AttentionMaskConverter.to_causal_4d that does not create a causal mask in case q_len == 1.
+        # is_causal = True if causal_mask is None and q_len > 1 else False
+
+        attn_output = torch.nn.functional.scaled_dot_product_attention(
+            query_states,
+            key_states,
+            value_states,
+            attn_mask=(
+                attention_mask if isinstance(attention_mask, torch.Tensor) else None
+            ),
+            dropout_p=self.attention_dropout if self.training else 0.0,
+            is_causal=False,  # hard coded
+        )
+
+        attn_output = attn_output.transpose(1, 2).contiguous()
+        attn_output = attn_output.view(bsz, q_len, self.hidden_size)
+
+        attn_output = self.o_proj(attn_output)
+
+        return attn_output, None, past_key_value
+
+
+class InfoGainDreamDecoderLayer(nn.Module):
+    def __init__(self, config: InfoGainDreamConfig, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+
+        if config.sliding_window and config._attn_implementation != "flash_attention_2":
+            logger.warning_once(
+                f"Sliding Window Attention is enabled but not implemented for `{config._attn_implementation}`; "
+                "unexpected results may be encountered."
+            )
+
+        # self.self_attn = InfoGainDream_ATTENTION_CLASSES[config._attn_implementation](config, layer_idx)
+        self.self_attn = InfoGainDreamSdpaAttention(config, layer_idx)
+
+        self.mlp = InfoGainDreamMLP(config)
+        self.input_layernorm = InfoGainDreamRMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+        self.post_attention_layernorm = InfoGainDreamRMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_value: Optional[Tuple[torch.Tensor]] = None,
+        output_attentions: Optional[bool] = False,
+        use_cache: Optional[bool] = False,
+        cache_position: Optional[torch.LongTensor] = None,
+        position_embeddings: Optional[
+            Tuple[torch.Tensor, torch.Tensor]
+        ] = None,  # will become mandatory in v4.46
+        dual_cache: Optional[bool] = False,
+        replace_position: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> Tuple[
+        torch.FloatTensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]
+    ]:
+        """
+        Args:
+            hidden_states (`torch.FloatTensor`): input to the layer of shape `(batch, seq_len, embed_dim)`
+            attention_mask (`torch.FloatTensor`, *optional*): attention mask of size
+                `(batch, sequence_length)` where padding elements are indicated by 0.
+            output_attentions (`bool`, *optional*):
+                Whether or not to return the attentions tensors of all attention layers. See `attentions` under
+                returned tensors for more detail.
+            use_cache (`bool`, *optional*):
+                If set to `True`, `past_key_values` key value states are returned and can be used to speed up decoding
+                (see `past_key_values`).
+            past_key_value (`Tuple(torch.FloatTensor)`, *optional*): cached past key and value projection states
+            cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
+                Indices depicting the position of the input sequence tokens in the sequence.
+            position_embeddings (`Tuple[torch.FloatTensor, torch.FloatTensor]`, *optional*):
+                Tuple containing the cosine and sine positional embeddings of shape `(batch_size, seq_len, head_dim)`,
+                with `head_dim` being the embedding dimension of each attention head.
+            kwargs (`dict`, *optional*):
+                Arbitrary kwargs to be ignored, used for FSDP and other methods that injects code
+                into the model
+        """
+
+        residual = hidden_states
+
+        hidden_states = self.input_layernorm(hidden_states)
+
+        # Self Attention
+        hidden_states, self_attn_weights, present_key_value = self.self_attn(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_value=past_key_value,
+            output_attentions=output_attentions,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            position_embeddings=position_embeddings,
+            dual_cache=dual_cache,
+            replace_position=replace_position,
+        )
+        hidden_states = residual + hidden_states
+
+        # Fully Connected
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+
+        outputs = (hidden_states,)
+
+        if output_attentions:
+            outputs += (self_attn_weights,)
+
+        if use_cache:
+            outputs += (present_key_value,)
+
+        return outputs
+
+
+class InfoGainDreamPreTrainedModel(PreTrainedModel):
+    config_class = InfoGainDreamConfig
+    base_model_prefix = "model"
+    supports_gradient_checkpointing = True
+    _no_split_modules = ["InfoGainDreamDecoderLayer"]
+    _skip_keys_device_placement = "past_key_values"
+    _supports_flash_attn_2 = True
+    _supports_sdpa = True
+    _supports_cache_class = True
+    _supports_quantized_cache = True
+    _supports_static_cache = True
+
+    def _init_weights(self, module):
+        std = self.config.initializer_range
+        if isinstance(module, nn.Linear):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.bias is not None:
+                module.bias.data.zero_()
+        elif isinstance(module, nn.Embedding):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.padding_idx is not None:
+                module.weight.data[module.padding_idx].zero_()
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: Optional[Union[str, os.PathLike]],
+        *model_args,
+        config: Optional[Union[PretrainedConfig, str, os.PathLike]] = None,
+        cache_dir: Optional[Union[str, os.PathLike]] = None,
+        ignore_mismatched_sizes: bool = False,
+        force_download: bool = False,
+        local_files_only: bool = False,
+        token: Optional[Union[str, bool]] = None,
+        revision: str = "main",
+        use_safetensors: Optional[bool] = None,
+        weights_only: bool = True,
+        **kwargs,
+    ):
+        _model = super().from_pretrained(
+            pretrained_model_name_or_path,
+            *model_args,
+            config=config,
+            cache_dir=cache_dir,
+            ignore_mismatched_sizes=ignore_mismatched_sizes,
+            force_download=force_download,
+            local_files_only=local_files_only,
+            token=token,
+            revision=revision,
+            use_safetensors=use_safetensors,
+            weights_only=weights_only,
+            **kwargs,
+        )
+        # NOTE(Lin): we need to override the generation config
+        # because the generation config loaded in `from_pretrained`
+        # does not include all the attributes of DreamGenerationConfig
+        resume_download = kwargs.get("resume_download", None)
+        proxies = kwargs.get("proxies", None)
+        subfolder = kwargs.get("subfolder", "")
+        from_auto_class = kwargs.get("_from_auto", False)
+        from_pipeline = kwargs.get("_from_pipeline", None)
+        _model.generation_config = DreamGenerationConfig.from_pretrained(
+            pretrained_model_name_or_path,
+            cache_dir=cache_dir,
+            force_download=force_download,
+            resume_download=resume_download,
+            proxies=proxies,
+            local_files_only=local_files_only,
+            token=token,
+            revision=revision,
+            subfolder=subfolder,
+            _from_auto=from_auto_class,
+            _from_pipeline=from_pipeline,
+        )
+        return _model
+
+
+class InfoGainDreamBaseModel(InfoGainDreamPreTrainedModel):
+    """
+    Transformer decoder consisting of *config.num_hidden_layers* layers. Each layer is a [`InfoGainDreamDecoderLayer`]
+
+    Args:
+        config: InfoGainDreamConfig
+    """
+
+    def __init__(self, config: InfoGainDreamConfig):
+        super().__init__(config)
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+
+        self.embed_tokens = nn.Embedding(
+            config.vocab_size, config.hidden_size, self.padding_idx
+        )
+        self.layers = nn.ModuleList(
+            [
+                InfoGainDreamDecoderLayer(config, layer_idx)
+                for layer_idx in range(config.num_hidden_layers)
+            ]
+        )
+        self._attn_implementation = config._attn_implementation
+        self.norm = InfoGainDreamRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rotary_emb = InfoGainDreamRotaryEmbedding(config=config)
+
+        self.gradient_checkpointing = False
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.embed_tokens = value
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[List[torch.FloatTensor]] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        dual_cache: Optional[bool] = False,
+        replace_position: Optional[torch.Tensor] = None,
+    ) -> Union[Tuple, BaseModelOutput]:
+        output_attentions = (
+            output_attentions
+            if output_attentions is not None
+            else self.config.output_attentions
+        )
+        output_hidden_states = (
+            output_hidden_states
+            if output_hidden_states is not None
+            else self.config.output_hidden_states
+        )
+        use_cache = use_cache if use_cache is not None else self.config.use_cache
+
+        return_dict = (
+            return_dict if return_dict is not None else self.config.use_return_dict
+        )
+
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError(
+                "You must specify exactly one of input_ids or inputs_embeds"
+            )
+
+        if self.gradient_checkpointing and self.training:
+            if use_cache:
+                logger.warning_once(
+                    "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`..."
+                )
+                use_cache = False
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        past_seen_tokens = (
+            past_key_values[0][0].shape[1] if past_key_values is not None else 0
+        )
+        if not dual_cache:
+            position_ids = torch.arange(
+                past_seen_tokens + inputs_embeds.shape[1], device=inputs_embeds.device
+            ).unsqueeze(0)
+        else:
+            if past_key_values is not None:
+                position_ids = torch.arange(
+                    past_seen_tokens, device=inputs_embeds.device
+                ).unsqueeze(0)
+            else:
+                position_ids = torch.arange(
+                    inputs_embeds.shape[1], device=inputs_embeds.device
+                ).unsqueeze(0)
+        attn_key_values: Optional[List[Tuple[torch.Tensor, torch.Tensor]]] = (
+            [] if use_cache else None
+        )
+
+        hidden_states = inputs_embeds
+
+        # create position embeddings to be shared across the decoder layers
+        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+
+        # decoder layers
+        all_hidden_states = () if output_hidden_states else None
+        all_self_attns = () if output_attentions else None
+
+        for layer_idx, decoder_layer in enumerate(self.layers):
+            if output_hidden_states:
+                all_hidden_states += (hidden_states,)
+
+            layer_past_key_value = (
+                past_key_values[layer_idx] if past_key_values is not None else None
+            )
+
+            if self.gradient_checkpointing and self.training:
+                layer_outputs = self._gradient_checkpointing_func(
+                    decoder_layer.__call__,
+                    hidden_states,
+                    attention_mask,
+                    position_ids,
+                    layer_past_key_value,
+                    output_attentions,
+                    use_cache,
+                    cache_position,
+                    position_embeddings,
+                    dual_cache,
+                    replace_position,
+                )
+            else:
+                layer_outputs = decoder_layer(
+                    hidden_states,
+                    attention_mask=attention_mask,
+                    position_ids=position_ids,
+                    past_key_value=layer_past_key_value,
+                    output_attentions=output_attentions,
+                    use_cache=use_cache,
+                    cache_position=cache_position,
+                    position_embeddings=position_embeddings,
+                    dual_cache=dual_cache,
+                    replace_position=replace_position,
+                )
+
+            hidden_states = layer_outputs[0]
+
+            if output_attentions:
+                all_self_attns += (layer_outputs[1],)
+            if use_cache:
+                attn_key_values.append(layer_outputs[1])
+
+        hidden_states = self.norm(hidden_states)
+
+        # add hidden states from the last decoder layer
+        if output_hidden_states:
+            all_hidden_states += (hidden_states,)
+
+        if not return_dict:
+            return tuple(
+                v
+                for v in [hidden_states, all_hidden_states, all_self_attns]
+                if v is not None
+            )
+        return BaseModelOutputWithPast(
+            last_hidden_state=hidden_states,
+            hidden_states=all_hidden_states,
+            attentions=all_self_attns,
+            past_key_values=attn_key_values,
+        )
+
+
+class InfoGainDreamModel(DreamGenerationMixin, InfoGainDreamPreTrainedModel):
+    _tied_weights_keys = ["lm_head.weight"]
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.model = InfoGainDreamBaseModel(config)
+        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    def reset_rope_parameters(self):
+        self.model.rotary_emb.reset_parameters()
+        for layer in self.model.layers:
+            layer.self_attn.rotary_emb.reset_parameters()
+
+    def get_input_embeddings(self):
+        return self.model.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.model.embed_tokens = value
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, new_embeddings):
+        self.lm_head = new_embeddings
+
+    def set_decoder(self, decoder):
+        self.model = decoder
+
+    def get_decoder(self):
+        return self.model
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[List[torch.FloatTensor]] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        labels: Optional[torch.LongTensor] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        num_logits_to_keep: int = 0,
+        dual_cache: Optional[bool] = False,
+        replace_position: Optional[torch.Tensor] = None,
+        **loss_kwargs,
+    ) -> Union[Tuple, MaskedLMOutput]:
+        output_attentions = (
+            output_attentions
+            if output_attentions is not None
+            else self.config.output_attentions
+        )
+        output_hidden_states = (
+            output_hidden_states
+            if output_hidden_states is not None
+            else self.config.output_hidden_states
+        )
+        return_dict = (
+            return_dict if return_dict is not None else self.config.use_return_dict
+        )
+
+        if (
+            isinstance(attention_mask, str)
+            and attention_mask == "full"
+            or attention_mask is None
+        ):
+            # whether attention_mask is full
+            pass
+
+        elif isinstance(attention_mask, torch.Tensor):
+            if not torch.any(attention_mask == 0.0):
+                attention_mask = "full"
+            elif attention_mask.dim() == 2:
+                # [B, L] → [B, 1, L, L]
+                attention_mask = torch.logical_and(
+                    attention_mask.unsqueeze(1).unsqueeze(-2),
+                    attention_mask.unsqueeze(1).unsqueeze(-1),
+                )
+                attention_mask = attention_mask.to(torch.bool)
+
+            elif attention_mask.dim() in (3, 4):
+                # already extended/broadcasted form
+                if attention_mask.dtype != torch.bool:
+                    attention_mask = attention_mask.to(torch.bool)
+
+            else:
+                raise ValueError(
+                    f"Unexpected attention_mask shape: {attention_mask.shape}"
+                )
+
+        else:
+            raise TypeError(f"Unsupported attention_mask type: {type(attention_mask)}")
+
+        # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            cache_position=cache_position,
+            dual_cache=dual_cache,
+            replace_position=replace_position,
+        )
+
+        hidden_states = outputs[0]
+        # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
+        logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :])
+
+        loss = None
+        if labels is not None:
+            loss = self.loss_function(logits, labels, self.vocab_size, **loss_kwargs)
+
+        if not return_dict:
+            output = (logits,) + outputs[1:]
+            return (loss,) + output if loss is not None else output
+
+        return MaskedLMOutputWithPastKeyValues(
+            loss=loss,
+            logits=logits,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+            past_key_values=outputs.past_key_values,
+        )

--- a/dllm/pipelines/infogain/dream/sampler.py
+++ b/dllm/pipelines/infogain/dream/sampler.py
@@ -1,5 +1,7 @@
 """
 Reference: https://huggingface.co/Dream-org/Dream-v0-Base-7B/blob/main/generation_utils.py
+
+Run: python -u examples/infogain/dream/sample.py --model_name_or_path "Dream-org/Dream-v0-Instruct-7B"
 """
 
 from dataclasses import dataclass
@@ -12,6 +14,16 @@ from dllm.core.samplers.base import BaseSampler, BaseSamplerConfig, BaseSamplerO
 from dllm.core.samplers.utils import get_num_transfer_tokens
 from dllm.pipelines.dream.models.generation_utils import top_k_logits, top_p_logits
 from dllm.pipelines.infogain import info_gain_ops as ig
+
+
+def _require_past_key_values(model_output, mode: str):
+    past_key_values = getattr(model_output, "past_key_values", None)
+    if past_key_values is None:
+        raise RuntimeError(
+            "Model did not return past_key_values with use_cache=True "
+            f"for Dream {mode} cache decoding."
+        )
+    return past_key_values
 
 
 def sample_tokens(
@@ -124,21 +136,55 @@ class InfoGainDreamSampler(BaseSampler):
             raise RuntimeError(
                 f"Unknown use_cache mode: {use_cache}. Expected None, 'prefix', or 'dual'."
             )
+        steps = int(steps)
+        if steps < 1:
+            raise ValueError(f"steps must be >= 1, got {steps}")
+        candidate_number = int(candidate_number)
+        position_temperature = float(position_temperature)
+        if candidate_number < 1:
+            raise ValueError(
+                f"candidate_number must be >= 1, got {candidate_number}"
+            )
+        if position_temperature < 0:
+            raise ValueError(
+                "position_temperature must be non-negative, "
+                f"got {position_temperature}"
+            )
+        ig.validate_info_gain_variant(info_gain_variant)
 
         # --- Initialization ---
         mask_token_id = self.tokenizer.mask_token_id
         eos_token_id = self.tokenizer.eos_token_id
 
+        if isinstance(inputs, torch.Tensor):
+            if inputs.dim() == 1:
+                inputs = [inputs.to(device=self.model.device, dtype=torch.long)]
+            elif inputs.dim() == 2:
+                inputs = [
+                    row.to(device=self.model.device, dtype=torch.long)
+                    for row in inputs
+                ]
+            else:
+                raise ValueError(
+                    f"inputs tensor must be rank 1 or 2, got shape={tuple(inputs.shape)}"
+                )
+        else:
+            if len(inputs) == 0:
+                raise ValueError("inputs is empty")
         if isinstance(inputs[0], list):
             inputs = [
                 torch.as_tensor(p, dtype=torch.long, device=self.model.device)
                 for p in inputs
             ]
         prompt_lens = [p.shape[0] for p in inputs]
-        if max_length is None and max_new_tokens is not None:
-            max_length = max_new_tokens + max(prompt_lens)
-        elif max_new_tokens is None and max_length is not None:
-            max_new_tokens = max_length - max(prompt_lens)
+        max_new_tokens, max_length = ig.resolve_generation_lengths(
+            max_new_tokens=max_new_tokens,
+            max_length=max_length,
+            max_prompt_len=max(prompt_lens),
+        )
+        block_size = max_new_tokens if block_size is None else int(block_size)
+        if block_size < 1:
+            raise ValueError(f"block_size must be >= 1, got {block_size}")
 
         B = len(inputs)
         T = max_length
@@ -189,6 +235,11 @@ class InfoGainDreamSampler(BaseSampler):
             raise RuntimeError(f"Unknown alg: {alg}")
 
         if use_cache is None:
+            if B != 1 and alg in ("info_gain", "confidence_threshold"):
+                raise ValueError(
+                    f"Dream alg={alg!r} currently supports batch size 1 only. "
+                    "Set eval batch_size=1 for this decoding path."
+                )
             mask_index = x == mask_token_id
             num_transfer_tokens_list = get_num_transfer_tokens(
                 mask_index=mask_index,
@@ -202,10 +253,6 @@ class InfoGainDreamSampler(BaseSampler):
             histories = [x.clone()] if return_dict else None
 
             if alg == "info_gain":
-                if B != 1:
-                    raise RuntimeError(
-                        "Dream Info-Gain decoding (alg='info_gain') requires batch size 1."
-                    )
                 if threshold is None:
                     raise RuntimeError(
                         "Pass `threshold` for high-confidence bypass (e.g. 0.8)."
@@ -268,8 +315,13 @@ class InfoGainDreamSampler(BaseSampler):
                             for ii, (act, x0) in enumerate(zip(actions, x0s)):
                                 x_batch[ii, act] = x0[0, act]
                             attn = attention_mask[0:1].expand(nc, -1)
+                            next_pos_id = (
+                                pos_id.expand(nc, -1) if pos_id is not None else None
+                            )
                             next_logits = self.model(
-                                x_batch, attn, pos_id.expand(nc, -1) if pos_id is not None else None
+                                x_batch,
+                                attn,
+                                next_pos_id,
                             ).logits
                             if right_shift_logits:
                                 next_logits = torch.cat(
@@ -301,6 +353,8 @@ class InfoGainDreamSampler(BaseSampler):
                 i = 0
                 while True:
                     mask_index = x == mask_token_id
+                    if not mask_index.any():
+                        break
                     logits = self.model(x, attention_mask, pos_id).logits
 
                     logits = shift_and_hook(i, x, logits)
@@ -315,9 +369,6 @@ class InfoGainDreamSampler(BaseSampler):
                         dtype=confidence.dtype,
                     )
                     full_confidence[mask_index] = confidence
-
-                    if not torch.any(mask_index[0]):
-                        continue
 
                     # Budget this step: top-k where k = num_transfer + leftover from past steps
                     current_transfer_tokens = (
@@ -359,6 +410,8 @@ class InfoGainDreamSampler(BaseSampler):
             else:
                 for i in range(effective_steps):
                     mask_index = x == mask_token_id
+                    if not mask_index.any():
+                        break
 
                     logits = self.model(x, attention_mask, pos_id).logits
 
@@ -405,20 +458,38 @@ class InfoGainDreamSampler(BaseSampler):
                 return BaseSamplerOutput(sequences=x, histories=histories)
 
         else:
+            if B != 1:
+                raise ValueError(
+                    "Dream prefix/dual cache decoding currently supports batch size 1. "
+                    "Set eval batch_size=1 or use use_cache=None with a batched-safe alg."
+                )
+            if alg == "info_gain":
+                raise ValueError(
+                    "Dream alg='info_gain' is only implemented for use_cache=None. "
+                    "Use alg='maskgit_plus', 'topk_margin', 'entropy', or "
+                    "'confidence_threshold' with cache modes."
+                )
+            if alg == "confidence_threshold" and threshold is None:
+                raise RuntimeError(
+                    "Missing `threshold` for alg == 'confidence_threshold'. "
+                    "Pass it via sample(..., threshold=...)."
+                )
             dual_cache = use_cache == "dual"
 
             gen_length = max_new_tokens
             if block_size is None:
                 block_size = gen_length
-            assert gen_length % block_size == 0, (
-                f"gen_length ({gen_length}) must be divisible by block_size "
-                f"({block_size})"
-            )
+            if gen_length % block_size != 0:
+                raise ValueError(
+                    f"gen_length ({gen_length}) must be divisible by block_size "
+                    f"({block_size})"
+                )
             num_blocks = gen_length // block_size
 
-            assert (
-                steps % num_blocks == 0
-            ), f"steps ({steps}) must be divisible by num_blocks ({num_blocks})"
+            if steps % num_blocks != 0:
+                raise ValueError(
+                    f"steps ({steps}) must be divisible by num_blocks ({num_blocks})"
+                )
             steps_per_block = steps // num_blocks
             timesteps = torch.linspace(1, eps, steps_per_block + 1, device=x.device)
             if attention_mask is not None and torch.any(attention_mask == 0):
@@ -447,7 +518,7 @@ class InfoGainDreamSampler(BaseSampler):
                 model_output = self.model(
                     x, cache_attention_mask, tok_idx, use_cache=True
                 )
-                past_key_values = model_output.past_key_values
+                past_key_values = _require_past_key_values(model_output, use_cache)
                 logits = shift_and_hook(global_step, x, model_output.logits)
 
                 _, x0_full = sample_tokens(
@@ -481,6 +552,8 @@ class InfoGainDreamSampler(BaseSampler):
 
                     mask_index = region == mask_token_id
                     mask_index[:, block_size:] = False
+                    if not mask_index.any():
+                        break
 
                     if cache_attention_mask != "full":
                         current_attention_mask = cache_attention_mask[
@@ -527,6 +600,9 @@ class InfoGainDreamSampler(BaseSampler):
                     x_[mask_index] = x0.clone()
 
                     if alg == "confidence_threshold":
+                        current_transfer_tokens = int(current_transfer_tokens.item())
+                        if current_transfer_tokens <= 0:
+                            break
                         selected_confidence, select_index = torch.topk(
                             full_confidence, current_transfer_tokens
                         )

--- a/dllm/pipelines/infogain/dream/sampler.py
+++ b/dllm/pipelines/infogain/dream/sampler.py
@@ -261,7 +261,7 @@ class InfoGainDreamSampler(BaseSampler):
                             if valid.shape[0] == 0:
                                 break
                             best_pos = valid[conf_base[0, valid].argmax()].unsqueeze(0)
-                            x[0, best_pos] = x0s[0][0, best_pos]
+                            x[0, best_pos] = x0s[0, best_pos]
                         else:
                             nc = len(actions)
                             x_batch = xx.expand(nc, -1).clone()

--- a/dllm/pipelines/infogain/dream/sampler.py
+++ b/dllm/pipelines/infogain/dream/sampler.py
@@ -235,11 +235,6 @@ class InfoGainDreamSampler(BaseSampler):
             raise RuntimeError(f"Unknown alg: {alg}")
 
         if use_cache is None:
-            if B != 1 and alg in ("info_gain", "confidence_threshold"):
-                raise ValueError(
-                    f"Dream alg={alg!r} currently supports batch size 1 only. "
-                    "Set eval batch_size=1 for this decoding path."
-                )
             mask_index = x == mask_token_id
             num_transfer_tokens_list = get_num_transfer_tokens(
                 mask_index=mask_index,
@@ -257,8 +252,6 @@ class InfoGainDreamSampler(BaseSampler):
                     raise RuntimeError(
                         "Pass `threshold` for high-confidence bypass (e.g. 0.8)."
                     )
-                gen_seg_start = T - seq_lens[0] + prompt_lens[0]
-                gen_seg_end = T
                 step_i = 0
                 while True:
                     mask_index = x == mask_token_id
@@ -266,31 +259,39 @@ class InfoGainDreamSampler(BaseSampler):
                         break
                     logits = self.model(x, attention_mask, pos_id).logits
                     logits = shift_and_hook(step_i, x, logits)
-                    lx = logits[0:1]
-                    xx = x[0:1]
-                    ma = mask_index[0:1]
+                    changed = False
+                    for row in range(B):
+                        gen_seg_start = T - seq_lens[row] + prompt_lens[row]
+                        gen_seg_end = T
+                        lx = logits[row : row + 1]
+                        xx = x[row : row + 1]
+                        ma = mask_index[row : row + 1]
+                        if not ma[:, gen_seg_start:gen_seg_end].any():
+                            continue
 
-                    probs = F.softmax(
-                        lx[:, gen_seg_start:gen_seg_end].float(), dim=-1
-                    )
-                    max_conf = probs.max(-1).values
-                    block_masked = ma[0, gen_seg_start:gen_seg_end]
-                    if (
-                        threshold > 0
-                        and block_masked.any()
-                        and (max_conf[0][block_masked] >= threshold).all()
-                    ):
-                        xx_new = ig.greedy_unmask_block(
-                            xx,
-                            lx,
-                            ma,
-                            gen_seg_start,
-                            gen_seg_end,
-                            temperature,
-                            mask_token_id,
+                        probs = F.softmax(
+                            lx[:, gen_seg_start:gen_seg_end].float(), dim=-1
                         )
-                        x[0:1] = xx_new
-                    else:
+                        max_conf = probs.max(-1).values
+                        block_masked = ma[0, gen_seg_start:gen_seg_end]
+                        if (
+                            threshold > 0
+                            and block_masked.any()
+                            and (max_conf[0][block_masked] >= threshold).all()
+                        ):
+                            xx_new = ig.greedy_unmask_block(
+                                xx,
+                                lx,
+                                ma,
+                                gen_seg_start,
+                                gen_seg_end,
+                                temperature,
+                                mask_token_id,
+                            )
+                            x[row : row + 1] = xx_new
+                            changed = True
+                            continue
+
                         k = 1
                         result = ig.generate_candidates(
                             lx,
@@ -306,17 +307,20 @@ class InfoGainDreamSampler(BaseSampler):
                         actions, x0s, conf_base, valid, _ = result
                         if actions is None:
                             if valid.shape[0] == 0:
-                                break
+                                continue
                             best_pos = valid[conf_base[0, valid].argmax()].unsqueeze(0)
-                            x[0, best_pos] = x0s[0, best_pos]
+                            x[row, best_pos] = x0s[0, best_pos]
+                            changed = True
                         else:
                             nc = len(actions)
                             x_batch = xx.expand(nc, -1).clone()
                             for ii, (act, x0) in enumerate(zip(actions, x0s)):
                                 x_batch[ii, act] = x0[0, act]
-                            attn = attention_mask[0:1].expand(nc, -1)
+                            attn = attention_mask[row : row + 1].expand(nc, -1)
                             next_pos_id = (
-                                pos_id.expand(nc, -1) if pos_id is not None else None
+                                pos_id[row : row + 1].expand(nc, -1)
+                                if pos_id is not None
+                                else None
                             )
                             next_logits = self.model(
                                 x_batch,
@@ -337,8 +341,11 @@ class InfoGainDreamSampler(BaseSampler):
                             )
                             best = int(J.argmax().item())
                             act = actions[best]
-                            x[0, act] = x0s[best][0, act]
+                            x[row, act] = x0s[best][0, act]
+                            changed = True
 
+                    if not changed:
+                        break
                     step_i += 1
                     x = generation_tokens_hook_func(step_i, x, logits)
                     if histories is not None:
@@ -370,28 +377,31 @@ class InfoGainDreamSampler(BaseSampler):
                     )
                     full_confidence[mask_index] = confidence
 
-                    # Budget this step: top-k where k = num_transfer + leftover from past steps
-                    current_transfer_tokens = (
-                        int(mask_index.sum().item())
-                        - num_transfer_tokens_list[0, i + 1 :].sum().item()
-                        if i + 1 < effective_steps
-                        else int(mask_index.sum().item())
-                    )
-
-                    selected_confidence, select_index = torch.topk(
-                        full_confidence, current_transfer_tokens
-                    )
                     transfer_index = torch.zeros_like(
                         mask_index, dtype=torch.bool, device=mask_index.device
                     )
+                    for row in range(B):
+                        row_mask_count = int(mask_index[row].sum().item())
+                        if row_mask_count == 0:
+                            continue
+                        if i + 1 < effective_steps:
+                            remaining_budget = int(
+                                num_transfer_tokens_list[row, i + 1 :].sum().item()
+                            )
+                            current_transfer_tokens = row_mask_count - remaining_budget
+                        else:
+                            current_transfer_tokens = row_mask_count
+                        current_transfer_tokens = max(
+                            1, min(row_mask_count, int(current_transfer_tokens))
+                        )
 
-                    # Start by selecting all top-k
-                    transfer_index[0, select_index[0]] = True
-
-                    # Threshold-filter within top-k (keep top-1 always, so start from 1)
-                    for kk in range(1, current_transfer_tokens):
-                        if selected_confidence[0, kk] < threshold:
-                            transfer_index[0, select_index[0, kk]] = False
+                        selected_confidence, select_index = torch.topk(
+                            full_confidence[row], current_transfer_tokens
+                        )
+                        transfer_index[row, select_index] = True
+                        for kk in range(1, current_transfer_tokens):
+                            if selected_confidence[kk] < threshold:
+                                transfer_index[row, select_index[kk]] = False
 
                     # Safety: never transfer unmasked positions
                     transfer_index &= mask_index
@@ -458,11 +468,6 @@ class InfoGainDreamSampler(BaseSampler):
                 return BaseSamplerOutput(sequences=x, histories=histories)
 
         else:
-            if B != 1:
-                raise ValueError(
-                    "Dream prefix/dual cache decoding currently supports batch size 1. "
-                    "Set eval batch_size=1 or use use_cache=None with a batched-safe alg."
-                )
             if alg == "info_gain":
                 raise ValueError(
                     "Dream alg='info_gain' is only implemented for use_cache=None. "
@@ -582,9 +587,9 @@ class InfoGainDreamSampler(BaseSampler):
 
                     confidence, x0 = sample_with_alg(mask_logits)
 
-                    current_transfer_tokens = (
+                    block_mask_counts = (
                         x[:, current_block_start:current_block_end] == mask_token_id
-                    ).sum()
+                    ).sum(dim=1)
 
                     full_confidence = torch.full_like(
                         region,
@@ -600,59 +605,57 @@ class InfoGainDreamSampler(BaseSampler):
                     x_[mask_index] = x0.clone()
 
                     if alg == "confidence_threshold":
-                        current_transfer_tokens = int(current_transfer_tokens.item())
-                        if current_transfer_tokens <= 0:
-                            break
-                        selected_confidence, select_index = torch.topk(
-                            full_confidence, current_transfer_tokens
-                        )
                         transfer_index = torch.zeros_like(
                             x_, device=x.device, dtype=torch.bool
                         )
-
-                        select_index = select_index.to(x.device)
-                        transfer_index[0, select_index[0]] = True
-                        for k in range(1, current_transfer_tokens):
-                            if selected_confidence[0, k] < threshold:
-                                transfer_index[0, select_index[0, k]] = False
-                        x[:, current_block_start:end][transfer_index] = x_[
-                            transfer_index
-                        ]
+                        for row in range(B):
+                            current_transfer_tokens = int(block_mask_counts[row].item())
+                            if current_transfer_tokens <= 0:
+                                continue
+                            selected_confidence, select_index = torch.topk(
+                                full_confidence[row], current_transfer_tokens
+                            )
+                            transfer_index[row, select_index] = True
+                            for k in range(1, current_transfer_tokens):
+                                if selected_confidence[k] < threshold:
+                                    transfer_index[row, select_index[k]] = False
+                        transfer_index &= mask_index
+                        target = x[:, current_block_start:end]
+                        target[transfer_index] = x_[transfer_index]
 
                     else:
                         if inner_step == steps_per_block:
                             break
                         t = timesteps[inner_step]
                         s = timesteps[inner_step + 1]
-                        num_mask_token = mask_index.sum() / mask_index.shape[0]
-
-                        number_transfer_tokens = (
-                            int(num_mask_token * (1 - s / t))
-                            if inner_step < steps_per_block - 1
-                            else int(num_mask_token)
+                        transfer_index = torch.zeros_like(
+                            x_, device=x.device, dtype=torch.bool
                         )
-                        if number_transfer_tokens > 0:
+                        for row in range(B):
+                            row_mask_count = int(block_mask_counts[row].item())
+                            number_transfer_tokens = (
+                                int(row_mask_count * (1 - s / t))
+                                if inner_step < steps_per_block - 1
+                                else row_mask_count
+                            )
+                            if number_transfer_tokens <= 0:
+                                continue
                             if alg_temp is None or alg_temp == 0:
                                 _, select_index = torch.topk(
-                                    full_confidence, number_transfer_tokens
+                                    full_confidence[row], number_transfer_tokens
                                 )
                             else:
-                                fc = full_confidence / alg_temp
+                                fc = full_confidence[row] / alg_temp
                                 fc = F.softmax(fc, dim=-1)
                                 select_index = torch.multinomial(
                                     fc, num_samples=number_transfer_tokens
                                 )
+                            transfer_index[row, select_index] = True
 
-                            transfer_index = torch.zeros_like(
-                                x_, device=x.device, dtype=torch.bool
-                            )
-                            transfer_index.scatter_(1, select_index, True)
-
-                            transfer_index &= mask_index
-                            x[:, current_block_start:end][transfer_index] = x_[
-                                transfer_index
-                            ]
-
+                        transfer_index &= mask_index
+                        if transfer_index.any():
+                            target = x[:, current_block_start:end]
+                            target[transfer_index] = x_[transfer_index]
                             x = generation_tokens_hook_func(global_step, x, logits)
                     if histories is not None:
                         histories.append(x.clone())

--- a/dllm/pipelines/infogain/dream/sampler.py
+++ b/dllm/pipelines/infogain/dream/sampler.py
@@ -85,6 +85,9 @@ class InfoGainDreamSamplerConfig(BaseSamplerConfig):
     candidate_number: int = 8
     position_temperature: float = 0.2
     info_gain_variant: str = "info_gain"  # "info_gain" | "lookum"
+    info_gain_cost_reduction: str = "sum"  # "sum" | "mean" ("entropy*")
+    info_gain_cost_weight: float = 1.0
+    info_gain_future_weight: float = 1.0
 
 
 @dataclass
@@ -129,6 +132,15 @@ class InfoGainDreamSampler(BaseSampler):
         info_gain_variant = kwargs.get(
             "info_gain_variant", config.info_gain_variant
         )
+        info_gain_cost_reduction = kwargs.get(
+            "info_gain_cost_reduction", config.info_gain_cost_reduction
+        )
+        info_gain_cost_weight = float(
+            kwargs.get("info_gain_cost_weight", config.info_gain_cost_weight)
+        )
+        info_gain_future_weight = float(
+            kwargs.get("info_gain_future_weight", config.info_gain_future_weight)
+        )
 
         if use_cache == "none":
             use_cache = None
@@ -151,6 +163,9 @@ class InfoGainDreamSampler(BaseSampler):
                 f"got {position_temperature}"
             )
         ig.validate_info_gain_variant(info_gain_variant)
+        info_gain_cost_reduction = ig.normalize_cost_reduction(
+            info_gain_cost_reduction
+        )
 
         # --- Initialization ---
         mask_token_id = self.tokenizer.mask_token_id
@@ -338,6 +353,9 @@ class InfoGainDreamSampler(BaseSampler):
                                 actions,
                                 mask_token_id,
                                 info_gain_variant,
+                                cost_reduction=info_gain_cost_reduction,
+                                cost_weight=info_gain_cost_weight,
+                                future_weight=info_gain_future_weight,
                             )
                             best = int(J.argmax().item())
                             act = actions[best]

--- a/dllm/pipelines/infogain/dream/sampler.py
+++ b/dllm/pipelines/infogain/dream/sampler.py
@@ -1,0 +1,603 @@
+"""
+Reference: https://huggingface.co/Dream-org/Dream-v0-Base-7B/blob/main/generation_utils.py
+"""
+
+from dataclasses import dataclass
+
+import torch
+import torch.distributions as dists
+import torch.nn.functional as F
+
+from dllm.core.samplers.base import BaseSampler, BaseSamplerConfig, BaseSamplerOutput
+from dllm.core.samplers.utils import get_num_transfer_tokens
+from dllm.pipelines.dream.models.generation_utils import top_k_logits, top_p_logits
+from dllm.pipelines.infogain import info_gain_ops as ig
+
+
+def sample_tokens(
+    logits: torch.Tensor,
+    temperature: float = 0.0,
+    top_p: float | None = None,
+    top_k: int | None = None,
+    margin_confidence: bool = False,
+    neg_entropy: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if temperature > 0:
+        logits = logits / temperature
+    if top_p is not None and top_p < 1:
+        logits = top_p_logits(logits, top_p)
+    if top_k is not None:
+        logits = top_k_logits(logits, top_k)
+
+    probs = torch.softmax(logits, dim=-1)
+
+    if temperature > 0:
+        try:
+            x0 = dists.Categorical(probs=probs).sample()
+            confidence = torch.gather(probs, -1, x0.unsqueeze(-1)).squeeze(-1)
+        except Exception:
+            confidence, x0 = probs.max(dim=-1)
+    else:
+        confidence, x0 = probs.max(dim=-1)
+
+    if margin_confidence:
+        sorted_probs, _ = torch.sort(probs, dim=-1, descending=True)
+        top1_probs = sorted_probs[:, 0]
+        top2_probs = sorted_probs[:, 1]
+        confidence = top1_probs - top2_probs
+
+    if neg_entropy:
+        epsilon = 1e-10
+        log_probs = torch.log(probs + epsilon)
+        confidence = torch.sum(probs * log_probs, dim=-1)
+
+    return confidence, x0
+
+
+@dataclass
+class InfoGainDreamSamplerConfig(BaseSamplerConfig):
+    max_new_tokens: int = 20
+    max_length: int = None  # Uses prompt length + max_new_tokens when None
+    steps: int = 512
+    eps: float = 1e-3
+    alg: str = "origin"
+    alg_temp: float = 0.0
+    temperature: float = 1.0
+    top_p: float = 1.0
+    top_k: int = 50
+    stochastic_transfer: bool = False
+    right_shift_logits: bool = True
+    threshold: float | None = None
+    use_cache: str | None = None  # None | "prefix" | "dual"
+    block_size: int = 32
+    candidate_number: int = 8
+    position_temperature: float = 0.2
+    info_gain_variant: str = "info_gain"  # "info_gain" | "lookum"
+
+
+@dataclass
+class InfoGainDreamSampler(BaseSampler):
+    @torch.no_grad()
+    def sample(
+        self,
+        inputs: list[torch.Tensor] | list[list[int]],
+        config: InfoGainDreamSamplerConfig | None = None,
+        generation_tokens_hook_func=lambda step, x, logits: x,
+        generation_logits_hook_func=lambda step, x, logits: logits,
+        **kwargs,
+    ) -> BaseSamplerOutput | torch.Tensor:
+        """
+        Diffusion-style masked decoding for *generation from inputs*.
+        (docstring unchanged)
+        """
+        config = config or InfoGainDreamSamplerConfig()
+
+        # Pull args from config with kwargs overrides
+        max_new_tokens = kwargs.get("max_new_tokens", config.max_new_tokens)
+        max_length = kwargs.get("max_length", config.max_length)
+        steps = kwargs.get("steps", config.steps)
+        eps = kwargs.get("eps", config.eps)
+        alg = kwargs.get("alg", config.alg)
+        alg_temp = kwargs.get("alg_temp", config.alg_temp)
+        temperature = kwargs.get("temperature", config.temperature)
+        top_p = kwargs.get("top_p", config.top_p)
+        top_k = kwargs.get("top_k", config.top_k)
+        stochastic_transfer = kwargs.get(
+            "stochastic_transfer", config.stochastic_transfer
+        )
+        threshold = kwargs.get("threshold", config.threshold)
+        use_cache = kwargs.get("use_cache", config.use_cache)
+        block_size = kwargs.get("block_size", config.block_size)
+        return_dict = kwargs.get("return_dict", config.return_dict)
+        right_shift_logits = kwargs.get("right_shift_logits", config.right_shift_logits)
+        candidate_number = kwargs.get("candidate_number", config.candidate_number)
+        position_temperature = kwargs.get(
+            "position_temperature", config.position_temperature
+        )
+        info_gain_variant = kwargs.get(
+            "info_gain_variant", config.info_gain_variant
+        )
+
+        if use_cache == "none":
+            use_cache = None
+        if use_cache not in (None, "prefix", "dual"):
+            raise RuntimeError(
+                f"Unknown use_cache mode: {use_cache}. Expected None, 'prefix', or 'dual'."
+            )
+
+        # --- Initialization ---
+        mask_token_id = self.tokenizer.mask_token_id
+        eos_token_id = self.tokenizer.eos_token_id
+
+        if isinstance(inputs[0], list):
+            inputs = [
+                torch.as_tensor(p, dtype=torch.long, device=self.model.device)
+                for p in inputs
+            ]
+        prompt_lens = [p.shape[0] for p in inputs]
+        if max_length is None and max_new_tokens is not None:
+            max_length = max_new_tokens + max(prompt_lens)
+        elif max_new_tokens is None and max_length is not None:
+            max_new_tokens = max_length - max(prompt_lens)
+
+        B = len(inputs)
+        T = max_length
+        x = torch.full((B, T), eos_token_id, dtype=torch.long, device=self.model.device)
+
+        seq_lens = []
+        for i, p in enumerate(inputs):
+            total_len = prompt_lens[i] + max_new_tokens
+            seq_lens.append(total_len)
+            start = T - total_len
+            x[i, start : start + prompt_lens[i]] = p
+            x[i, start + prompt_lens[i] : T] = mask_token_id
+
+        attention_mask = torch.zeros((B, T), dtype=torch.long, device=self.model.device)
+        for j, L in enumerate(seq_lens):
+            if L > 0:
+                attention_mask[j, -L:] = 1  # Mandate to be left-padding
+
+        if attention_mask is not None and torch.any(attention_mask == 0):
+            pos_id = attention_mask.long().cumsum(-1) - 1
+            pos_id.masked_fill_(attention_mask == 0, 1)
+        else:
+            pos_id = None
+
+        def shift_and_hook(
+            step: int | None, tokens: torch.Tensor, logits: torch.Tensor
+        ):
+            if right_shift_logits:
+                logits = torch.cat([logits[:, :1], logits[:, :-1]], dim=1)
+            return generation_logits_hook_func(step, tokens, logits)
+
+        def sample_with_alg(
+            mask_logits: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            kwargs_tokens = {
+                "temperature": temperature,
+                "top_p": top_p,
+                "top_k": top_k,
+            }
+            if alg in ("maskgit_plus", "confidence_threshold"):
+                return sample_tokens(mask_logits, **kwargs_tokens)
+            if alg == "topk_margin":
+                return sample_tokens(
+                    mask_logits, margin_confidence=True, **kwargs_tokens
+                )
+            if alg == "entropy":
+                return sample_tokens(mask_logits, neg_entropy=True, **kwargs_tokens)
+            raise RuntimeError(f"Unknown alg: {alg}")
+
+        if use_cache is None:
+            mask_index = x == mask_token_id
+            num_transfer_tokens_list = get_num_transfer_tokens(
+                mask_index=mask_index,
+                steps=steps,
+                scheduler=self.scheduler,
+                stochastic=stochastic_transfer,
+            )
+            effective_steps = num_transfer_tokens_list.size(1)
+            # --- Iterative refinement ---
+            x = generation_tokens_hook_func(None, x, None)
+            histories = [x.clone()] if return_dict else None
+
+            if alg == "info_gain":
+                if B != 1:
+                    raise RuntimeError(
+                        "Dream Info-Gain decoding (alg='info_gain') requires batch size 1."
+                    )
+                if threshold is None:
+                    raise RuntimeError(
+                        "Pass `threshold` for high-confidence bypass (e.g. 0.8)."
+                    )
+                gen_seg_start = T - seq_lens[0] + prompt_lens[0]
+                gen_seg_end = T
+                step_i = 0
+                while True:
+                    mask_index = x == mask_token_id
+                    if not mask_index.any():
+                        break
+                    logits = self.model(x, attention_mask, pos_id).logits
+                    logits = shift_and_hook(step_i, x, logits)
+                    lx = logits[0:1]
+                    xx = x[0:1]
+                    ma = mask_index[0:1]
+
+                    probs = F.softmax(
+                        lx[:, gen_seg_start:gen_seg_end].float(), dim=-1
+                    )
+                    max_conf = probs.max(-1).values
+                    block_masked = ma[0, gen_seg_start:gen_seg_end]
+                    if (
+                        threshold > 0
+                        and block_masked.any()
+                        and (max_conf[0][block_masked] >= threshold).all()
+                    ):
+                        xx_new = ig.greedy_unmask_block(
+                            xx,
+                            lx,
+                            ma,
+                            gen_seg_start,
+                            gen_seg_end,
+                            temperature,
+                            mask_token_id,
+                        )
+                        x[0:1] = xx_new
+                    else:
+                        k = 1
+                        result = ig.generate_candidates(
+                            lx,
+                            xx,
+                            ma,
+                            gen_seg_start,
+                            gen_seg_end,
+                            k,
+                            candidate_number,
+                            temperature,
+                            position_temperature,
+                        )
+                        actions, x0s, conf_base, valid, _ = result
+                        if actions is None:
+                            if valid.shape[0] == 0:
+                                break
+                            best_pos = valid[conf_base[0, valid].argmax()].unsqueeze(0)
+                            x[0, best_pos] = x0s[0][0, best_pos]
+                        else:
+                            nc = len(actions)
+                            x_batch = xx.expand(nc, -1).clone()
+                            for ii, (act, x0) in enumerate(zip(actions, x0s)):
+                                x_batch[ii, act] = x0[0, act]
+                            attn = attention_mask[0:1].expand(nc, -1)
+                            next_logits = self.model(
+                                x_batch, attn, pos_id.expand(nc, -1) if pos_id is not None else None
+                            ).logits
+                            if right_shift_logits:
+                                next_logits = torch.cat(
+                                    [next_logits[:, :1], next_logits[:, :-1]], dim=1
+                                )
+                            _, _, J = ig.score_candidates(
+                                lx,
+                                next_logits,
+                                x_batch,
+                                actions,
+                                mask_token_id,
+                                info_gain_variant,
+                            )
+                            best = int(J.argmax().item())
+                            act = actions[best]
+                            x[0, act] = x0s[best][0, act]
+
+                    step_i += 1
+                    x = generation_tokens_hook_func(step_i, x, logits)
+                    if histories is not None:
+                        histories.append(x.clone())
+
+            elif alg == "confidence_threshold":
+                if threshold is None:
+                    raise RuntimeError(
+                        "Missing `threshold` for alg == 'confidence_threshold'. "
+                        "Pass it via sample(..., threshold=...)."
+                    )
+                i = 0
+                while True:
+                    mask_index = x == mask_token_id
+                    logits = self.model(x, attention_mask, pos_id).logits
+
+                    logits = shift_and_hook(i, x, logits)
+
+                    mask_logits = logits[mask_index]
+                    confidence, x0 = sample_with_alg(mask_logits)
+
+                    full_confidence = torch.full(
+                        mask_index.shape,
+                        -torch.inf,
+                        device=logits.device,
+                        dtype=confidence.dtype,
+                    )
+                    full_confidence[mask_index] = confidence
+
+                    if not torch.any(mask_index[0]):
+                        continue
+
+                    # Budget this step: top-k where k = num_transfer + leftover from past steps
+                    current_transfer_tokens = (
+                        int(mask_index.sum().item())
+                        - num_transfer_tokens_list[0, i + 1 :].sum().item()
+                        if i + 1 < effective_steps
+                        else int(mask_index.sum().item())
+                    )
+
+                    selected_confidence, select_index = torch.topk(
+                        full_confidence, current_transfer_tokens
+                    )
+                    transfer_index = torch.zeros_like(
+                        mask_index, dtype=torch.bool, device=mask_index.device
+                    )
+
+                    # Start by selecting all top-k
+                    transfer_index[0, select_index[0]] = True
+
+                    # Threshold-filter within top-k (keep top-1 always, so start from 1)
+                    for kk in range(1, current_transfer_tokens):
+                        if selected_confidence[0, kk] < threshold:
+                            transfer_index[0, select_index[0, kk]] = False
+
+                    # Safety: never transfer unmasked positions
+                    transfer_index &= mask_index
+
+                    x_ = torch.full_like(x, mask_token_id, device=self.model.device)
+                    x_[mask_index] = x0.clone()
+                    x[transfer_index] = x_[transfer_index]
+                    i += 1
+                    x = generation_tokens_hook_func(i, x, logits)
+                    if histories is not None:
+                        histories.append(x.clone())
+
+                    if not torch.any(x == mask_token_id):
+                        break
+
+            else:
+                for i in range(effective_steps):
+                    mask_index = x == mask_token_id
+
+                    logits = self.model(x, attention_mask, pos_id).logits
+
+                    logits = shift_and_hook(i, x, logits)
+
+                    mask_logits = logits[mask_index]
+                    confidence, x0 = sample_with_alg(mask_logits)
+
+                    full_confidence = torch.full(
+                        mask_index.shape,
+                        -torch.inf,
+                        device=logits.device,
+                        dtype=confidence.dtype,
+                    )
+                    full_confidence[mask_index] = confidence
+
+                    for j in range(full_confidence.shape[0]):
+                        number_transfer_tokens = num_transfer_tokens_list[j, i]
+                        if number_transfer_tokens > 0:
+                            if alg_temp is None or alg_temp == 0:
+                                _, transfer_index = torch.topk(
+                                    full_confidence[j], number_transfer_tokens
+                                )
+                            else:
+                                fc = full_confidence[j] / alg_temp
+                                fc = F.softmax(fc, dim=-1)
+                                transfer_index = torch.multinomial(
+                                    fc, num_samples=number_transfer_tokens
+                                )
+
+                            x_ = torch.full_like(
+                                x, mask_token_id, device=self.model.device
+                            )
+                            x_[mask_index] = x0.clone()
+                            x[j, transfer_index] = x_[j, transfer_index]
+
+                    x = generation_tokens_hook_func(i, x, logits)
+                    if histories is not None:
+                        histories.append(x.clone())
+
+            if not return_dict:
+                return x
+            else:
+                return BaseSamplerOutput(sequences=x, histories=histories)
+
+        else:
+            dual_cache = use_cache == "dual"
+
+            gen_length = max_new_tokens
+            if block_size is None:
+                block_size = gen_length
+            assert gen_length % block_size == 0, (
+                f"gen_length ({gen_length}) must be divisible by block_size "
+                f"({block_size})"
+            )
+            num_blocks = gen_length // block_size
+
+            assert (
+                steps % num_blocks == 0
+            ), f"steps ({steps}) must be divisible by num_blocks ({num_blocks})"
+            steps_per_block = steps // num_blocks
+            timesteps = torch.linspace(1, eps, steps_per_block + 1, device=x.device)
+            if attention_mask is not None and torch.any(attention_mask == 0):
+                cache_attention_mask = torch.logical_and(
+                    attention_mask.bool().unsqueeze(1).unsqueeze(-2),
+                    attention_mask.bool().unsqueeze(1).unsqueeze(-1),
+                )
+                tok_idx = pos_id
+            else:
+                cache_attention_mask = "full"
+                tok_idx = None
+
+            x = generation_tokens_hook_func(None, x, None)
+            histories = [x.clone()] if return_dict else None
+            global_step = 0
+
+            gen_start = T - max_new_tokens  # == max(prompt_lens)
+
+            past_key_values = None
+
+            for num_block in range(num_blocks):
+                current_block_start = gen_start + num_block * block_size
+                current_block_end = current_block_start + block_size
+
+                # update cache
+                model_output = self.model(
+                    x, cache_attention_mask, tok_idx, use_cache=True
+                )
+                past_key_values = model_output.past_key_values
+                logits = shift_and_hook(global_step, x, model_output.logits)
+
+                _, x0_full = sample_tokens(
+                    logits, temperature=temperature, top_p=top_p, top_k=top_k
+                )
+                x[:, current_block_start] = x0_full[:, current_block_start]
+
+                x = generation_tokens_hook_func(global_step, x, logits)
+                if histories is not None:
+                    histories.append(x.clone())
+                global_step += 1
+
+                replace_position = None
+                if not dual_cache:
+                    new_past_key_values = []
+                    for li in range(len(past_key_values)):
+                        new_past_key_values.append(())
+                        for kj in range(len(past_key_values[li])):
+                            new_past_key_values[li] += (
+                                past_key_values[li][kj][:, :current_block_start, :],
+                            )
+                    past_key_values = new_past_key_values
+                else:
+                    replace_position = torch.zeros_like(x, dtype=torch.bool)
+                    replace_position[:, current_block_start:current_block_end] = True
+
+                inner_step = 1
+                while True:
+                    end = current_block_end if dual_cache else None
+                    region = x[:, current_block_start:end]
+
+                    mask_index = region == mask_token_id
+                    mask_index[:, block_size:] = False
+
+                    if cache_attention_mask != "full":
+                        current_attention_mask = cache_attention_mask[
+                            :, :, :, current_block_start:
+                        ]
+                    else:
+                        current_attention_mask = cache_attention_mask
+
+                    region_tok_idx = (
+                        tok_idx[:, current_block_start:end]
+                        if tok_idx is not None
+                        else None
+                    )
+
+                    model_output = self.model(
+                        region,
+                        current_attention_mask,
+                        region_tok_idx,
+                        past_key_values=past_key_values,
+                        use_cache=True,
+                        dual_cache=dual_cache,
+                        replace_position=replace_position,
+                    )
+                    logits = shift_and_hook(global_step, x, model_output.logits)
+                    mask_logits = logits[mask_index]
+
+                    confidence, x0 = sample_with_alg(mask_logits)
+
+                    current_transfer_tokens = (
+                        x[:, current_block_start:current_block_end] == mask_token_id
+                    ).sum()
+
+                    full_confidence = torch.full_like(
+                        region,
+                        -torch.inf,
+                        device=self.model.device,
+                        dtype=logits.dtype,
+                    )
+                    full_confidence[mask_index] = confidence
+                    full_confidence[:, block_size:] = -torch.inf
+                    x_ = torch.full_like(
+                        region, mask_token_id, device=self.model.device
+                    )
+                    x_[mask_index] = x0.clone()
+
+                    if alg == "confidence_threshold":
+                        selected_confidence, select_index = torch.topk(
+                            full_confidence, current_transfer_tokens
+                        )
+                        transfer_index = torch.zeros_like(
+                            x_, device=x.device, dtype=torch.bool
+                        )
+
+                        select_index = select_index.to(x.device)
+                        transfer_index[0, select_index[0]] = True
+                        for k in range(1, current_transfer_tokens):
+                            if selected_confidence[0, k] < threshold:
+                                transfer_index[0, select_index[0, k]] = False
+                        x[:, current_block_start:end][transfer_index] = x_[
+                            transfer_index
+                        ]
+
+                    else:
+                        if inner_step == steps_per_block:
+                            break
+                        t = timesteps[inner_step]
+                        s = timesteps[inner_step + 1]
+                        num_mask_token = mask_index.sum() / mask_index.shape[0]
+
+                        number_transfer_tokens = (
+                            int(num_mask_token * (1 - s / t))
+                            if inner_step < steps_per_block - 1
+                            else int(num_mask_token)
+                        )
+                        if number_transfer_tokens > 0:
+                            if alg_temp is None or alg_temp == 0:
+                                _, select_index = torch.topk(
+                                    full_confidence, number_transfer_tokens
+                                )
+                            else:
+                                fc = full_confidence / alg_temp
+                                fc = F.softmax(fc, dim=-1)
+                                select_index = torch.multinomial(
+                                    fc, num_samples=number_transfer_tokens
+                                )
+
+                            transfer_index = torch.zeros_like(
+                                x_, device=x.device, dtype=torch.bool
+                            )
+                            transfer_index.scatter_(1, select_index, True)
+
+                            transfer_index &= mask_index
+                            x[:, current_block_start:end][transfer_index] = x_[
+                                transfer_index
+                            ]
+
+                            x = generation_tokens_hook_func(global_step, x, logits)
+                    if histories is not None:
+                        histories.append(x.clone())
+                    global_step += 1
+
+                    inner_step += 1
+                    if (
+                        x[:, current_block_start:current_block_end] == mask_token_id
+                    ).sum() == 0:
+                        break
+
+            if not return_dict:
+                return x
+            else:
+                return BaseSamplerOutput(sequences=x, histories=histories)
+
+    @torch.no_grad()
+    def infill(
+        self,
+        inputs: list[torch.Tensor] | list[list[int]],
+        config: InfoGainDreamSamplerConfig | None = None,
+        **kwargs,
+    ) -> BaseSamplerOutput:
+        raise NotImplementedError

--- a/dllm/pipelines/infogain/info_gain_ops.py
+++ b/dllm/pipelines/infogain/info_gain_ops.py
@@ -54,6 +54,25 @@ def validate_info_gain_variant(variant: str) -> None:
         )
 
 
+def normalize_cost_reduction(cost_reduction: str) -> str:
+    aliases = {
+        "sum": "sum",
+        "entropy": "sum",
+        "mean": "mean",
+        "avg": "mean",
+        "average": "mean",
+        "entropy*": "mean",
+        "entropy_star": "mean",
+    }
+    try:
+        return aliases[cost_reduction]
+    except KeyError as exc:
+        raise ValueError(
+            f"Unknown Info-Gain cost reduction {cost_reduction!r}; "
+            "expected 'sum' or 'mean' ('entropy*')."
+        ) from exc
+
+
 def compute_entropy(logits: torch.Tensor, eps: float = 1e-12) -> torch.Tensor:
     """Per-position Shannon entropy: [B, L, V] → [B, L]."""
     p = F.softmax(logits.float(), dim=-1).clamp(min=eps)
@@ -137,20 +156,31 @@ def score_candidates(
     actions: list,
     mask_id: int,
     variant: str = "info_gain",
+    cost_reduction: str = "sum",
+    cost_weight: float = 1.0,
+    future_weight: float = 1.0,
 ):
     """Return (C, H_next, J) per candidate; higher J is better."""
     validate_info_gain_variant(variant)
+    cost_reduction = normalize_cost_reduction(cost_reduction)
     ne = compute_entropy(next_logits)
     rm = x_batch == mask_id
     H_next = torch.where(rm, ne, ne.new_zeros(1)).sum(-1) / (rm.sum(-1).float() + 1e-10)
 
     if variant == "lookum":
-        J = -H_next
+        J = -future_weight * H_next
         C = H_next.new_zeros(H_next.shape)
     else:
         ce = compute_entropy(logits)
-        C = torch.stack([ce[0, a].sum() for a in actions])
-        J = -C - H_next
+        costs = []
+        for action in actions:
+            action_entropy = ce[0, action]
+            if cost_reduction == "mean":
+                costs.append(action_entropy.mean())
+            else:
+                costs.append(action_entropy.sum())
+        C = torch.stack(costs)
+        J = -cost_weight * C - future_weight * H_next
 
     return C, H_next, J
 

--- a/dllm/pipelines/infogain/info_gain_ops.py
+++ b/dllm/pipelines/infogain/info_gain_ops.py
@@ -13,6 +13,47 @@ import torch
 import torch.nn.functional as F
 
 
+def resolve_generation_lengths(
+    max_new_tokens: int | None,
+    max_length: int | None,
+    max_prompt_len: int,
+) -> tuple[int, int]:
+    """Resolve generation length args into positive (max_new_tokens, max_length)."""
+    if max_prompt_len < 0:
+        raise ValueError(f"max_prompt_len must be non-negative, got {max_prompt_len}")
+
+    if max_new_tokens is None and max_length is None:
+        raise ValueError("Either max_new_tokens or max_length must be set.")
+
+    if max_new_tokens is not None:
+        max_new_tokens = int(max_new_tokens)
+        if max_new_tokens <= 0:
+            raise ValueError(
+                f"max_new_tokens must be positive, got {max_new_tokens}"
+            )
+
+    if max_length is None:
+        assert max_new_tokens is not None
+        max_length = max_prompt_len + max_new_tokens
+    else:
+        max_length = int(max_length)
+        if max_length <= max_prompt_len:
+            raise ValueError(
+                "max_length must leave room for at least one generated token: "
+                f"max_length={max_length}, max_prompt_len={max_prompt_len}"
+            )
+        max_new_tokens = max_length - max_prompt_len
+
+    return int(max_new_tokens), int(max_length)
+
+
+def validate_info_gain_variant(variant: str) -> None:
+    if variant not in ("info_gain", "lookum"):
+        raise ValueError(
+            f"Unknown Info-Gain variant {variant!r}; expected 'info_gain' or 'lookum'."
+        )
+
+
 def compute_entropy(logits: torch.Tensor, eps: float = 1e-12) -> torch.Tensor:
     """Per-position Shannon entropy: [B, L, V] → [B, L]."""
     p = F.softmax(logits.float(), dim=-1).clamp(min=eps)
@@ -98,6 +139,7 @@ def score_candidates(
     variant: str = "info_gain",
 ):
     """Return (C, H_next, J) per candidate; higher J is better."""
+    validate_info_gain_variant(variant)
     ne = compute_entropy(next_logits)
     rm = x_batch == mask_id
     H_next = torch.where(rm, ne, ne.new_zeros(1)).sum(-1) / (rm.sum(-1).float() + 1e-10)

--- a/dllm/pipelines/infogain/info_gain_ops.py
+++ b/dllm/pipelines/infogain/info_gain_ops.py
@@ -1,0 +1,133 @@
+"""
+Shared Info-Gain scoring utilities (ported from Information-Gain-Sampler).
+
+Reference: https://github.com/yks23/Information-Gain-Sampler
+Paper: Yang et al., "Improving Sampling for Masked Diffusion Models via Information Gain" (arXiv:2602.18176).
+
+Run smoke test: python -c "import torch; from dllm.pipelines.infogain import info_gain_ops as ig; print(ig.compute_entropy(torch.randn(1,3,5)).shape)"
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+
+def compute_entropy(logits: torch.Tensor, eps: float = 1e-12) -> torch.Tensor:
+    """Per-position Shannon entropy: [B, L, V] → [B, L]."""
+    p = F.softmax(logits.float(), dim=-1).clamp(min=eps)
+    return -(p * p.log()).sum(-1)
+
+
+def add_gumbel_noise(logits: torch.Tensor, temperature: float) -> torch.Tensor:
+    if temperature == 0.0:
+        return logits
+    u = torch.zeros_like(logits).uniform_().clamp(1e-10, 1 - 1e-10)
+    gumbel = -(-u.log()).log()
+    return logits + temperature * gumbel
+
+
+def generate_candidates(
+    logits: torch.Tensor,
+    x: torch.Tensor,
+    mask_allowed: torch.Tensor,
+    block_start: int,
+    block_end: int,
+    k: int,
+    n_candidates: int,
+    token_temp: float,
+    pos_temp: float,
+):
+    """
+    Generate N diverse candidate actions via Gumbel sampling.
+
+    Returns (actions, x0s, conf_base, valid, probs_base) or (None, x0_base, ...) for trivial path.
+    """
+    device = x.device
+    neg = torch.finfo(torch.float32).min
+
+    block_mask = torch.zeros_like(mask_allowed)
+    block_mask[:, block_start:block_end] = mask_allowed[:, block_start:block_end]
+
+    x0_base = torch.argmax(add_gumbel_noise(logits, token_temp), dim=-1)
+    x0_base = torch.where(mask_allowed, x0_base, x)
+
+    probs_base = F.softmax(logits.float(), dim=-1)
+    conf_base = torch.gather(probs_base, -1, x0_base.unsqueeze(-1)).squeeze(-1)
+    conf_base = torch.where(block_mask, conf_base, torch.full_like(conf_base, neg))
+
+    valid = torch.where(conf_base[0] > neg)[0]
+    nv = valid.shape[0]
+
+    if nv == 0 or nv <= k or pos_temp <= 0 or n_candidates <= 1:
+        return None, x0_base, conf_base, valid, probs_base
+
+    actions, x0s, seen = [], [], set()
+    for c in range(n_candidates):
+        if c == 0:
+            x0_c, conf_c = x0_base, conf_base
+        else:
+            x0_c = torch.argmax(add_gumbel_noise(logits, token_temp), dim=-1)
+            x0_c = torch.where(mask_allowed, x0_c, x)
+            cf = torch.gather(probs_base, -1, x0_c.unsqueeze(-1)).squeeze(-1)
+            conf_c = torch.where(block_mask, cf, torch.full_like(cf, neg))
+
+        vc = conf_c[0, valid]
+        if c == 0:
+            _, tk = torch.topk(vc, min(k, nv))
+        else:
+            g = -torch.log(-torch.log(torch.rand(nv, device=device) + 1e-10) + 1e-10)
+            _, tk = torch.topk(vc / pos_temp + g, min(k, nv))
+
+        act = valid[tk]
+        key = tuple(sorted(act.tolist()))
+        if key not in seen:
+            seen.add(key)
+            actions.append(act)
+            x0s.append(x0_c)
+
+    return actions, x0s, conf_base, valid, probs_base
+
+
+def score_candidates(
+    logits: torch.Tensor,
+    next_logits: torch.Tensor,
+    x_batch: torch.Tensor,
+    actions: list,
+    mask_id: int,
+    variant: str = "info_gain",
+):
+    """Return (C, H_next, J) per candidate; higher J is better."""
+    ne = compute_entropy(next_logits)
+    rm = x_batch == mask_id
+    H_next = torch.where(rm, ne, ne.new_zeros(1)).sum(-1) / (rm.sum(-1).float() + 1e-10)
+
+    if variant == "lookum":
+        J = -H_next
+        C = H_next.new_zeros(H_next.shape)
+    else:
+        ce = compute_entropy(logits)
+        C = torch.stack([ce[0, a].sum() for a in actions])
+        J = -C - H_next
+
+    return C, H_next, J
+
+
+def greedy_unmask_block(
+    x: torch.Tensor,
+    logits: torch.Tensor,
+    mask_allowed: torch.Tensor,
+    bs: int,
+    be: int,
+    temperature: float,
+    mask_id: int,
+):
+    """Fill all remaining masks in [bs, be) greedily (high-confidence bypass)."""
+    x0 = torch.argmax(add_gumbel_noise(logits, temperature), dim=-1)
+    x0 = torch.where(mask_allowed, x0, x)
+    out = x.clone()
+    m = mask_allowed.clone()
+    m[:, :bs] = False
+    m[:, be:] = False
+    out = torch.where(m, x0, out)
+    return out

--- a/dllm/pipelines/infogain/llada/__init__.py
+++ b/dllm/pipelines/infogain/llada/__init__.py
@@ -1,16 +1,13 @@
-"""Info-Gain LLaDA pipeline."""
+"""
+Info-Gain LLaDA pipeline.
 
-from .models import InfoGainLLaDAConfig, InfoGainLLaDAModelLM
-from .sampler import InfoGainLLaDASampler, InfoGainLLaDASamplerConfig
+Run import check:
+    python -c "from dllm.pipelines.infogain.llada import InfoGainLLaDASampler"
+"""
 
-try:
-    from transformers import AutoConfig, AutoModel, AutoModelForMaskedLM
+from __future__ import annotations
 
-    AutoConfig.register("infogain_llada", InfoGainLLaDAConfig)
-    AutoModel.register(InfoGainLLaDAConfig, InfoGainLLaDAModelLM)
-    AutoModelForMaskedLM.register(InfoGainLLaDAConfig, InfoGainLLaDAModelLM)
-except ImportError:
-    pass
+from importlib import import_module
 
 __all__ = [
     "InfoGainLLaDAConfig",
@@ -18,3 +15,45 @@ __all__ = [
     "InfoGainLLaDASampler",
     "InfoGainLLaDASamplerConfig",
 ]
+
+
+def _register_model_classes(config_cls, model_cls) -> None:
+    try:
+        from transformers import AutoConfig, AutoModel, AutoModelForMaskedLM
+
+        AutoConfig.register("infogain_llada", config_cls)
+        AutoModel.register(config_cls, model_cls)
+        AutoModelForMaskedLM.register(config_cls, model_cls)
+    except (ImportError, ValueError):
+        pass
+
+
+def _load_models():
+    module = import_module(f"{__name__}.models")
+    config_cls = module.InfoGainLLaDAConfig
+    model_cls = module.InfoGainLLaDAModelLM
+    _register_model_classes(config_cls, model_cls)
+    globals()["InfoGainLLaDAConfig"] = config_cls
+    globals()["InfoGainLLaDAModelLM"] = model_cls
+    return module
+
+
+def _load_sampler():
+    module = import_module(f"{__name__}.sampler")
+    globals()["InfoGainLLaDASampler"] = module.InfoGainLLaDASampler
+    globals()["InfoGainLLaDASamplerConfig"] = module.InfoGainLLaDASamplerConfig
+    return module
+
+
+def __getattr__(name: str):
+    if name in ("InfoGainLLaDAConfig", "InfoGainLLaDAModelLM"):
+        _load_models()
+        return globals()[name]
+    if name in ("InfoGainLLaDASampler", "InfoGainLLaDASamplerConfig"):
+        _load_sampler()
+        return globals()[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(list(globals().keys()) + __all__)

--- a/dllm/pipelines/infogain/llada/__init__.py
+++ b/dllm/pipelines/infogain/llada/__init__.py
@@ -1,0 +1,20 @@
+"""Info-Gain LLaDA pipeline."""
+
+from .models import InfoGainLLaDAConfig, InfoGainLLaDAModelLM
+from .sampler import InfoGainLLaDASampler, InfoGainLLaDASamplerConfig
+
+try:
+    from transformers import AutoConfig, AutoModel, AutoModelForMaskedLM
+
+    AutoConfig.register("infogain_llada", InfoGainLLaDAConfig)
+    AutoModel.register(InfoGainLLaDAConfig, InfoGainLLaDAModelLM)
+    AutoModelForMaskedLM.register(InfoGainLLaDAConfig, InfoGainLLaDAModelLM)
+except ImportError:
+    pass
+
+__all__ = [
+    "InfoGainLLaDAConfig",
+    "InfoGainLLaDAModelLM",
+    "InfoGainLLaDASampler",
+    "InfoGainLLaDASamplerConfig",
+]

--- a/dllm/pipelines/infogain/llada/eval.py
+++ b/dllm/pipelines/infogain/llada/eval.py
@@ -31,7 +31,6 @@ class InfoGainLLaDAEvalSamplerConfig(InfoGainLLaDASamplerConfig):
 @dataclass
 class InfoGainLLaDAEvalConfig(MDLMEvalConfig):
     max_length: int = 4096
-    batch_size: int = 1
 
     def get_model_config(self, pretrained: str):
         return InfoGainLLaDAConfig.from_pretrained(pretrained)

--- a/dllm/pipelines/infogain/llada/eval.py
+++ b/dllm/pipelines/infogain/llada/eval.py
@@ -31,6 +31,7 @@ class InfoGainLLaDAEvalSamplerConfig(InfoGainLLaDASamplerConfig):
 @dataclass
 class InfoGainLLaDAEvalConfig(MDLMEvalConfig):
     max_length: int = 4096
+    batch_size: int = 1
 
     def get_model_config(self, pretrained: str):
         return InfoGainLLaDAConfig.from_pretrained(pretrained)

--- a/dllm/pipelines/infogain/llada/eval.py
+++ b/dllm/pipelines/infogain/llada/eval.py
@@ -1,0 +1,59 @@
+"""
+accelerate launch --num_processes 4 \\
+    dllm/pipelines/infogain/llada/eval.py \\
+    --tasks gsm8k \\
+    --model infogain_llada \\
+    --apply_chat_template \\
+    --num_fewshot 5 \\
+    --model_args "pretrained=GSAI-ML/LLaDA-8B-Instruct,use_cache=none,max_new_tokens=256,steps=256,block_size=32,threshold=0.8,candidate_number=8,suppress_tokens=[],begin_suppress_tokens=[]"
+"""
+
+from dataclasses import dataclass
+
+from lm_eval.__main__ import cli_evaluate
+from lm_eval.api.registry import register_model
+
+from dllm.core.eval import MDLMEvalConfig, MDLMEvalHarness
+from dllm.pipelines.infogain.llada import (
+    InfoGainLLaDAConfig,
+    InfoGainLLaDASampler,
+    InfoGainLLaDASamplerConfig,
+)
+
+
+@dataclass
+class InfoGainLLaDAEvalSamplerConfig(InfoGainLLaDASamplerConfig):
+    max_new_tokens: int = 1024
+    steps: int = 1024
+    block_size: int = 1024
+
+
+@dataclass
+class InfoGainLLaDAEvalConfig(MDLMEvalConfig):
+    max_length: int = 4096
+
+    def get_model_config(self, pretrained: str):
+        return InfoGainLLaDAConfig.from_pretrained(pretrained)
+
+
+@register_model("infogain_llada")
+class InfoGainLLaDAEvalHarness(MDLMEvalHarness):
+    def __init__(
+        self,
+        eval_config: InfoGainLLaDAEvalConfig | None = None,
+        sampler_config: InfoGainLLaDASamplerConfig | None = None,
+        sampler_cls: type[InfoGainLLaDASampler] = InfoGainLLaDASampler,
+        **kwargs,
+    ):
+        eval_config = eval_config or InfoGainLLaDAEvalConfig()
+        sampler_config = sampler_config or InfoGainLLaDAEvalSamplerConfig()
+        super().__init__(
+            eval_config=eval_config,
+            sampler_config=sampler_config,
+            sampler_cls=sampler_cls,
+            **kwargs,
+        )
+
+
+if __name__ == "__main__":
+    cli_evaluate()

--- a/dllm/pipelines/infogain/llada/models/__init__.py
+++ b/dllm/pipelines/infogain/llada/models/__init__.py
@@ -1,0 +1,6 @@
+"""Info-Gain LLaDA model registration."""
+
+from .configuration_llada import InfoGainLLaDAConfig
+from .modeling_llada import InfoGainLLaDAModelLM
+
+__all__ = ["InfoGainLLaDAConfig", "InfoGainLLaDAModelLM"]

--- a/dllm/pipelines/infogain/llada/models/configuration_llada.py
+++ b/dllm/pipelines/infogain/llada/models/configuration_llada.py
@@ -1,0 +1,15 @@
+"""
+LLaDA Info-Gain configuration wrapper.
+Registers a distinct model_type for AutoConfig while reusing LLaDA hyperparameters.
+
+Run (from repo root): python -c "from dllm.pipelines.infogain.llada.models import InfoGainLLaDAConfig; print(InfoGainLLaDAConfig)"
+"""
+
+from dllm.pipelines.llada.models.configuration_llada import LLaDAConfig
+
+
+class InfoGainLLaDAConfig(LLaDAConfig):
+    model_type = "infogain_llada"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)

--- a/dllm/pipelines/infogain/llada/models/modeling_llada.py
+++ b/dllm/pipelines/infogain/llada/models/modeling_llada.py
@@ -1,0 +1,2006 @@
+# Copyright 2025 NVIDIA CORPORATION & AFFILIATES
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Modified from LLaDA repos: https://github.com/ML-GSAI/LLaDA
+
+from __future__ import annotations
+
+import logging
+import math
+import sys
+from abc import abstractmethod
+from collections import defaultdict
+from functools import partial
+from typing import (
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    cast,
+)
+from dataclasses import fields
+from typing import List, Optional, Tuple, Union
+
+try:
+    from torch.nn.attention.flex_attention import flex_attention, create_block_mask
+
+    FLEX_ATTN_AVAILABLE = True
+except:
+    FLEX_ATTN_AVAILABLE = False
+import torch
+import torch.backends.cuda
+import torch.nn as nn
+import torch.nn.functional as F
+from torch import einsum
+from transformers import PreTrainedModel
+from transformers.modeling_outputs import CausalLMOutputWithPast
+from transformers.models.auto import AutoModel
+from transformers.cache_utils import Cache
+
+from dllm.pipelines.llada.models.configuration_llada import (
+    LLaDAConfig,
+    StrEnum,
+    InitFnType,
+    ActivationType,
+    BlockType,
+    LayerNormType,
+    ModelConfig,
+    ActivationCheckpointingStrategy,
+)
+from .configuration_llada import InfoGainLLaDAConfig
+
+if sys.version_info.minor > 8:
+    from collections.abc import MutableMapping
+elif sys.version_info.minor == 8:
+    from typing import MutableMapping
+else:
+    raise SystemExit("This script supports Python 3.8 or higher")
+
+__all__ = [
+    "LayerNormBase",
+    "LayerNorm",
+    "RMSLayerNorm",
+    "GemmaRMSLayerNorm",
+    "RotaryEmbedding",
+    "Activation",
+    "GELU",
+    "ReLU",
+    "SwiGLU",
+    "InfoGainLLaDABlock",
+    "InfoGainLLaDASequentialBlock",
+    "InfoGainLLaDALlamaBlock",
+    "InfoGainLLaDABlockDiffBlock",
+    "InfoGainLLaDABlockGroup",
+    "InfoGainLLaDAModel",
+    "InfoGainLLaDAModelLM",
+    "InfoGainLLaDAOutput",
+    "InfoGainLLaDAGenerateOutput",
+]
+
+
+log = logging.getLogger(__name__)
+
+
+@torch.compile()
+def scaled_dot_product_attention(
+    q, k, v, mask=None, attn_mask=None, dropout_p=0.0, is_causal=False
+):
+    return F.scaled_dot_product_attention(
+        q, k, v, attn_mask=attn_mask, dropout_p=dropout_p, is_causal=is_causal
+    )
+
+
+class ModuleType(StrEnum):
+    in_module = "in"
+    out_module = "out"
+    emb = "emb"
+    final_out = "final_out"
+
+
+def init_weights(
+    config: ModelConfig,
+    module: Union[nn.Linear, nn.Embedding],
+    d: Optional[int] = None,
+    layer_id: Optional[int] = None,
+    std_factor: float = 1.0,
+    type_of_module: Optional[ModuleType] = None,
+) -> None:
+    """
+    Initialize weights of a linear or embedding module.
+
+    :param config: The model config.
+    :param module: The linear or embedding submodule to initialize.
+    :param d: The effective input dimensionality of the weights. This could be smaller than the actual dimensions
+        for fused layers.
+    :param layer_id: When set, the standard deviation for the "mitchell" method will be adjusted by
+        ``1 / sqrt(2 * (layer_id + 1))``.
+    """
+    d = d if d is not None else config.d_model
+    if config.init_fn == InitFnType.normal:
+        std = config.init_std * std_factor
+        if config.init_cutoff_factor is not None:
+            cutoff_value = config.init_cutoff_factor * std
+            nn.init.trunc_normal_(
+                module.weight, mean=0.0, std=std, a=-cutoff_value, b=cutoff_value
+            )
+        else:
+            nn.init.normal_(module.weight, mean=0.0, std=std)
+    elif config.init_fn == InitFnType.mitchell:
+        std = std_factor / math.sqrt(d)
+        if layer_id is not None:
+            std = std / math.sqrt(2 * (layer_id + 1))
+        nn.init.trunc_normal_(module.weight, mean=0.0, std=std, a=-3 * std, b=3 * std)
+    elif config.init_fn == InitFnType.kaiming_normal:
+        nn.init.kaiming_normal_(module.weight, nonlinearity="relu")
+    elif config.init_fn == InitFnType.fan_in:
+        std = std_factor / math.sqrt(d)
+        nn.init.normal_(module.weight, mean=0.0, std=std)
+    elif config.init_fn == InitFnType.full_megatron:
+        if type_of_module is None:
+            raise RuntimeError(
+                f"When using the {InitFnType.full_megatron} init, every module must have a type."
+            )
+
+        cutoff_factor = config.init_cutoff_factor
+        if cutoff_factor is None:
+            cutoff_factor = 3
+
+        if type_of_module == ModuleType.in_module:
+            # for att_proj (same as QKV), ff_proj
+            std = config.init_std
+        elif type_of_module == ModuleType.out_module:
+            # for attn_out, ff_out
+            std = config.init_std / math.sqrt(2.0 * config.n_layers)
+        elif type_of_module == ModuleType.emb:
+            # positional embeddings (wpe)
+            # token embeddings (wte)
+            std = config.init_std
+        elif type_of_module == ModuleType.final_out:
+            # final output (ff_out)
+            std = config.d_model**-0.5
+        else:
+            raise RuntimeError(f"Unknown module type '{type_of_module}'")
+        nn.init.trunc_normal_(
+            module.weight,
+            mean=0.0,
+            std=std,
+            a=-cutoff_factor * std,
+            b=cutoff_factor * std,
+        )
+    else:
+        raise NotImplementedError(config.init_fn)
+
+    if isinstance(module, nn.Linear):
+        if module.bias is not None:
+            nn.init.zeros_(module.bias)
+
+        if config.init_fn == InitFnType.normal and getattr(
+            module, "_is_residual", False
+        ):
+            with torch.no_grad():
+                module.weight.div_(math.sqrt(2 * config.n_layers))
+
+
+def ensure_finite_(
+    x: torch.Tensor, check_neg_inf: bool = True, check_pos_inf: bool = False
+):
+    """
+    Modify ``x`` in place to replace ``float("-inf")`` with the minimum value of the dtype when ``check_neg_inf``
+    is ``True`` and to replace ``float("inf")`` with the maximum value of the dtype when ``check_pos_inf`` is ``True``.
+    """
+    if check_neg_inf:
+        x.masked_fill_(x == float("-inf"), torch.finfo(x.dtype).min)
+    if check_pos_inf:
+        x.masked_fill_(x == float("inf"), torch.finfo(x.dtype).max)
+
+
+def activation_checkpoint_function(cfg: ModelConfig):
+    preserve_rng_state = (
+        (cfg.attention_dropout == 0.0)
+        and (cfg.embedding_dropout == 0.0)
+        and (cfg.residual_dropout == 0.0)
+    )
+    from torch.utils.checkpoint import checkpoint
+
+    return partial(
+        checkpoint,
+        preserve_rng_state=preserve_rng_state,
+        use_reentrant=False,
+    )
+
+
+class BufferCache(dict, MutableMapping[str, torch.Tensor]):
+    """
+    Cache for attention biases and other things that would normally be stored as buffers.
+    We avoid using buffers because we've run into various issues doing so with FSDP.
+    In general it appears the way FSDP handles buffers is not well-defined.
+    It doesn't shard them but apparently it does synchronize them across processes, which we want to avoid
+    since (A) it isn't necessary, and (B) we sometimes have `-inf` in these biases which might get turned into
+    NaNs when they're synchronized due to casting or some other issue.
+    """
+
+
+def _non_meta_init_device(config: ModelConfig) -> torch.device:
+    if config.init_device is not None and config.init_device != "meta":
+        return torch.device(config.init_device)
+    else:
+        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+class Dropout(nn.Dropout):
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        if self.p == 0.0:
+            return input
+        else:
+            return F.dropout(input, self.p, self.training, self.inplace)
+
+
+class LayerNormBase(nn.Module):
+    def __init__(
+        self,
+        config: ModelConfig,
+        *,
+        size: Optional[int] = None,
+        elementwise_affine: Optional[bool] = True,
+        eps: float = 1e-05,
+    ):
+        super().__init__()
+        self.config = config
+        self.eps = eps
+        self.normalized_shape = (size or config.d_model,)
+        if elementwise_affine or (
+            elementwise_affine is None and self.config.layer_norm_with_affine
+        ):
+            self.weight = nn.Parameter(
+                torch.ones(self.normalized_shape, device=config.init_device)
+            )
+            use_bias = self.config.bias_for_layer_norm
+            if use_bias is None:
+                use_bias = self.config.include_bias
+            if use_bias:
+                self.bias = nn.Parameter(
+                    torch.zeros(self.normalized_shape, device=config.init_device)
+                )
+            else:
+                self.register_parameter("bias", None)
+        else:
+            self.register_parameter("bias", None)
+            self.register_parameter("weight", None)
+
+    @abstractmethod
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+    @classmethod
+    def build(
+        cls, config: ModelConfig, size: Optional[int] = None, **kwargs
+    ) -> LayerNormBase:
+        if config.layer_norm_type == LayerNormType.default:
+            return LayerNorm(config, size=size, low_precision=False, **kwargs)
+        elif config.layer_norm_type == LayerNormType.low_precision:
+            return LayerNorm(config, size=size, low_precision=True, **kwargs)
+        elif config.layer_norm_type == LayerNormType.rms:
+            return RMSLayerNorm(config, size=size, **kwargs)
+        elif config.layer_norm_type == LayerNormType.gemma_rms:
+            return GemmaRMSLayerNorm(config, size=size, **kwargs)
+        else:
+            raise NotImplementedError(
+                f"Unknown LayerNorm type: '{config.layer_norm_type}'"
+            )
+
+    def _cast_if_autocast_enabled(
+        self, tensor: torch.Tensor, dtype: Optional[torch.dtype] = None
+    ) -> torch.Tensor:
+        # NOTE: `is_autocast_enabled()` only checks for CUDA autocast, so we use the separate function
+        # `is_autocast_cpu_enabled()` for CPU autocast.
+        # See https://github.com/pytorch/pytorch/issues/110966.
+        if tensor.device.type == "cuda" and torch.is_autocast_enabled():
+            return tensor.to(
+                dtype=dtype if dtype is not None else torch.get_autocast_gpu_dtype()
+            )
+        elif tensor.device.type == "cpu" and torch.is_autocast_cpu_enabled():
+            return tensor.to(
+                dtype=dtype if dtype is not None else torch.get_autocast_cpu_dtype()
+            )
+        else:
+            return tensor
+
+    def reset_parameters(self):
+        if self.weight is not None:
+            torch.nn.init.ones_(self.weight)  # type: ignore
+        if self.bias is not None:
+            torch.nn.init.zeros_(self.bias)  # type: ignore
+
+
+class LayerNorm(LayerNormBase):
+    """
+    The default :class:`LayerNorm` implementation which can optionally run in low precision.
+    """
+
+    def __init__(
+        self,
+        config: ModelConfig,
+        size: Optional[int] = None,
+        low_precision: bool = False,
+        elementwise_affine: Optional[bool] = None,
+        eps: float = 1e-05,
+    ):
+        super().__init__(
+            config, size=size, elementwise_affine=elementwise_affine, eps=eps
+        )
+        self.low_precision = low_precision
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.low_precision:
+            module_device = x.device
+            downcast_x = self._cast_if_autocast_enabled(x)
+            downcast_weight = (
+                self._cast_if_autocast_enabled(self.weight)
+                if self.weight is not None
+                else self.weight
+            )
+            downcast_bias = (
+                self._cast_if_autocast_enabled(self.bias)
+                if self.bias is not None
+                else self.bias
+            )
+            with torch.autocast(enabled=False, device_type=module_device.type):
+                return F.layer_norm(
+                    downcast_x,
+                    self.normalized_shape,
+                    weight=downcast_weight,
+                    bias=downcast_bias,
+                    eps=self.eps,
+                )
+        else:
+            return F.layer_norm(
+                x,
+                self.normalized_shape,
+                weight=self.weight,
+                bias=self.bias,
+                eps=self.eps,
+            )
+
+
+class RMSLayerNorm(LayerNormBase):
+    """
+    RMS layer norm, a simplified :class:`LayerNorm` implementation
+    """
+
+    def __init__(
+        self,
+        config: ModelConfig,
+        size: Optional[int] = None,
+        elementwise_affine: Optional[bool] = None,
+        eps: float = 1e-5,
+    ):
+        super().__init__(
+            config,
+            size=size,
+            elementwise_affine=elementwise_affine,
+            eps=config.rms_norm_eps,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        with torch.autocast(enabled=False, device_type=x.device.type):
+            og_dtype = x.dtype
+            x = x.to(torch.float32)
+            variance = x.pow(2).mean(-1, keepdim=True)
+            x = x * torch.rsqrt(variance + self.eps)
+            x = x.to(og_dtype)
+
+        if self.weight is not None:
+            if self.bias is not None:
+                return self.weight * x + self.bias
+            else:
+                return self.weight * x
+        else:
+            return x
+
+
+class GemmaRMSLayerNorm(LayerNormBase):
+    """
+    Gemma RMS layer norm, a simplified :class:`LayerNorm` implementation
+    """
+
+    def __init__(
+        self,
+        config: ModelConfig,
+        size: Optional[int] = None,
+        elementwise_affine: Optional[bool] = None,
+        eps: float = 1e-5,
+    ):
+        super().__init__(
+            config,
+            size=size,
+            elementwise_affine=elementwise_affine,
+            eps=config.rms_norm_eps,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        with torch.autocast(enabled=False, device_type=x.device.type):
+            og_dtype = x.dtype
+            x = x.to(torch.float32)
+            variance = x.pow(2).mean(-1, keepdim=True)
+            x = x * torch.rsqrt(variance + self.eps)
+            x = x.to(og_dtype)
+
+        if self.weight is not None:
+            if self.bias is not None:
+                return x * (1 + self.weight) + self.bias
+            else:
+                return x * (1 + self.weight)
+        else:
+            return x
+
+
+class RotaryEmbedding(nn.Module):
+    """
+    [Rotary positional embeddings (RoPE)](https://arxiv.org/abs/2104.09864).
+    """
+
+    def __init__(self, config: ModelConfig, cache: BufferCache):
+        super().__init__()
+        self.config = config
+        self.__cache = cache
+        # Warm up cache.
+        self.rope_theta = config.rope_theta
+        self.get_rotary_embedding(
+            config.max_sequence_length, _non_meta_init_device(config)
+        )
+
+    def get_rotary_embedding(
+        self, seq_len: int, device: torch.device
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if (
+            (pos_sin := self.__cache.get("rope_pos_sin")) is not None
+            and (pos_cos := self.__cache.get("rope_pos_cos")) is not None
+            and pos_sin.shape[-2] >= seq_len
+            and pos_cos.shape[-2] >= seq_len
+        ):
+            if pos_sin.device != device:
+                pos_sin = pos_sin.to(device)
+                self.__cache["rope_pos_sin"] = pos_sin
+            if pos_cos.device != device:
+                pos_cos = pos_cos.to(device)
+                self.__cache["rope_pos_cos"] = pos_cos
+            return pos_sin[:, :, :seq_len, :], pos_cos[:, :, :seq_len, :]
+
+        with torch.autocast(device.type, enabled=False):
+            dim = self.config.d_model // self.config.n_heads
+            inv_freq = 1.0 / (
+                self.rope_theta
+                ** (torch.arange(0, dim, 2, device=device, dtype=torch.float) / dim)
+            )
+            seq = torch.arange(seq_len, device=device, dtype=torch.float)
+            freqs = einsum("i , j -> i j", seq, inv_freq)
+            positions = torch.cat((freqs, freqs), dim=-1)
+            pos_sin, pos_cos = (
+                positions.sin()[None, None, :, :],
+                positions.cos()[None, None, :, :],
+            )
+        self.__cache["rope_pos_sin"] = pos_sin
+        self.__cache["rope_pos_cos"] = pos_cos
+        return pos_sin, pos_cos
+
+    def rotate_half(self, x: torch.Tensor) -> torch.Tensor:
+        B, nh, T, hs = x.size()
+        x = x.view(B, nh, T, 2, hs // 2)
+        x1, x2 = x.unbind(dim=-2)
+        return torch.cat((-x2, x1), dim=-1)
+
+    def apply_rotary_pos_emb(
+        self, pos_sin: torch.Tensor, pos_cos: torch.Tensor, t: torch.Tensor
+    ) -> torch.Tensor:
+        return ((t * pos_cos) + (self.rotate_half(t) * pos_sin)).to(t.dtype)
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        block_end_index: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if self.config.rope_full_precision:
+            q_, k_ = q.float(), k.float()
+        else:
+            q_, k_ = q, k
+
+        with torch.autocast(q.device.type, enabled=False):
+            query_len, key_len = q_.shape[-2], k_.shape[-2]
+            pos_sin, pos_cos = self.get_rotary_embedding(key_len, q_.device)
+            pos_sin = pos_sin.type_as(q_)
+            pos_cos = pos_cos.type_as(q_)
+
+            # Build tensor indices instead of using .item()
+            if block_end_index is None:
+                start = key_len - query_len
+                end = key_len
+            else:
+                # block_end_index is a tensor; keep ops tensor-based
+                start = block_end_index - query_len
+                end = block_end_index
+
+            # Make an index tensor [start, ..., end-1] on the right device/dtype
+            idx = torch.arange(start, end, device=q_.device, dtype=torch.long)
+
+            # Use index_select on the sequence dimension (dim=2)
+            pos_sin_slice = pos_sin.index_select(2, idx)
+            pos_cos_slice = pos_cos.index_select(2, idx)
+
+            q_ = self.apply_rotary_pos_emb(pos_sin_slice, pos_cos_slice, q_)
+            k_ = self.apply_rotary_pos_emb(pos_sin, pos_cos, k_)
+
+        return q_.type_as(q), k_.type_as(k)
+
+
+class Activation(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+
+    @abstractmethod
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def output_multiplier(self) -> float:
+        raise NotImplementedError
+
+    @classmethod
+    def build(cls, config: ModelConfig) -> Activation:
+        if config.activation_type == ActivationType.gelu:
+            return cast(Activation, GELU(approximate="none"))
+        elif config.activation_type == ActivationType.relu:
+            return cast(Activation, ReLU(inplace=False))
+        elif config.activation_type == ActivationType.silu:
+            return cast(Activation, SiLU(inplace=False))
+        elif config.activation_type == ActivationType.swiglu:
+            return SwiGLU(config)
+        else:
+            raise NotImplementedError(f"Unknown activation: '{config.activation_type}'")
+
+
+class GELU(nn.GELU):
+    @property
+    def output_multiplier(self) -> float:
+        return 1.0
+
+
+class ReLU(nn.ReLU):
+    @property
+    def output_multiplier(self) -> float:
+        return 1.0
+
+
+class SiLU(nn.SiLU):
+    @property
+    def output_multiplier(self) -> float:
+        return 1.0
+
+
+class SwiGLU(Activation):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x, gate = x.chunk(2, dim=-1)
+        return F.silu(gate) * x
+
+    @property
+    def output_multiplier(self) -> float:
+        return 0.5
+
+
+def causal_attention_bias(seq_len: int, device: torch.device) -> torch.FloatTensor:
+    att_bias = torch.triu(
+        torch.ones(seq_len, seq_len, device=device, dtype=torch.float),
+        diagonal=1,
+    )
+    att_bias.masked_fill_(att_bias == 1, torch.finfo(att_bias.dtype).min)
+    return att_bias.view(1, 1, seq_len, seq_len)  # type: ignore
+
+
+def get_causal_attention_bias(
+    cache: BufferCache, seq_len: int, device: torch.device
+) -> torch.Tensor:
+    if (
+        causal_bias := cache.get("causal_attention_bias")
+    ) is not None and causal_bias.shape[-1] >= seq_len:
+        if causal_bias.device != device:
+            causal_bias = causal_bias.to(device)
+            cache["causal_attention_bias"] = causal_bias
+        return causal_bias
+    with torch.autocast(device.type, enabled=False):
+        causal_bias = causal_attention_bias(seq_len, device)
+    cache["causal_attention_bias"] = causal_bias
+    return causal_bias
+
+
+def alibi_attention_bias(
+    seq_len: int, config: ModelConfig, device: torch.device
+) -> torch.FloatTensor:
+    alibi_bias = torch.arange(1 - seq_len, 1, dtype=torch.float, device=device).view(
+        1, 1, 1, seq_len
+    )
+
+    # shape: (1, 1, seq_len, seq_len)
+    alibi_bias = alibi_bias - torch.arange(
+        1 - seq_len, 1, dtype=torch.float, device=device
+    ).view(1, 1, seq_len, 1)
+    alibi_bias.abs_().mul_(-1)
+
+    # shape: (n_heads,)
+    m = torch.arange(1, config.n_heads + 1, dtype=torch.float, device=device)
+    m.mul_(config.alibi_bias_max / config.n_heads)
+
+    # shape: (1, n_heads, seq_len, seq_len)
+    return alibi_bias * (1.0 / (2 ** m.view(1, config.n_heads, 1, 1)))  # type: ignore
+
+
+class InfoGainLLaDABlock(nn.Module):
+    """
+    A base class for transformer block implementations.
+    """
+
+    def __init__(self, layer_id: int, config: ModelConfig, cache: BufferCache):
+        super().__init__()
+        self.layer_id = layer_id
+        self.config = config
+        self.hidden_size = (
+            config.mlp_hidden_size
+            if config.mlp_hidden_size is not None
+            else config.mlp_ratio * config.d_model
+        )
+        self.__cache = cache
+        assert config.d_model % config.n_heads == 0
+
+        self._activation_checkpoint_fn = None
+
+        # Dropout.
+        self.dropout = Dropout(config.residual_dropout)
+
+        # Layer norms.
+        self.k_norm: Optional[LayerNormBase] = None
+        self.q_norm: Optional[LayerNormBase] = None
+        if config.attention_layer_norm:
+            self.k_norm = LayerNormBase.build(
+                config,
+                size=(config.d_model // config.n_heads) * config.effective_n_kv_heads,
+                elementwise_affine=config.attention_layer_norm_with_affine,
+            )
+            self.q_norm = LayerNormBase.build(
+                config, elementwise_affine=config.attention_layer_norm_with_affine
+            )
+
+        # Activation function.
+        self.act = Activation.build(config)
+        assert (self.act.output_multiplier * self.hidden_size) % 1 == 0
+
+        # Attention output projection.
+        self.attn_out = nn.Linear(
+            config.d_model,
+            config.d_model,
+            bias=config.include_bias,
+            device=config.init_device,
+        )
+
+        # Feed-forward output projection.
+        self.ff_out = nn.Linear(
+            int(self.act.output_multiplier * self.hidden_size),
+            config.d_model,
+            bias=config.include_bias,
+            device=config.init_device,
+        )
+        self.ff_out._is_residual = True  # type: ignore
+
+        # Rotary embeddings.
+        if self.config.rope:
+            self.rotary_emb = RotaryEmbedding(config, self.__cache)
+
+        self.flash_attn_func = None
+        if config.flash_attention:
+            try:
+                from flash_attn import flash_attn_func  # type: ignore
+
+                self.flash_attn_func = flash_attn_func
+            except ModuleNotFoundError:
+                pass
+
+    def reset_parameters(self):
+        if self.k_norm is not None:
+            self.k_norm.reset_parameters()
+        if self.q_norm is not None:
+            self.q_norm.reset_parameters()
+        init_weights(
+            self.config,
+            self.attn_out,
+            d=self.config.d_model,
+            layer_id=self.layer_id,
+            type_of_module=ModuleType.out_module,
+        )
+        init_weights(
+            self.config,
+            self.ff_out,
+            d=self.ff_out.in_features,
+            layer_id=self.layer_id,
+            type_of_module=ModuleType.out_module,
+        )
+
+    def set_activation_checkpointing(
+        self, strategy: Optional[ActivationCheckpointingStrategy]
+    ):
+        if strategy == ActivationCheckpointingStrategy.fine_grained:
+            self._activation_checkpoint_fn = activation_checkpoint_function(self.config)
+        else:
+            self._activation_checkpoint_fn = None
+
+    @classmethod
+    def _cast_attn_bias(
+        cls, bias: torch.Tensor, input_dtype: torch.dtype
+    ) -> torch.Tensor:
+        target_dtype = input_dtype
+        # NOTE: `is_autocast_enabled()` only checks for CUDA autocast, so we use the separate function
+        # `is_autocast_cpu_enabled()` for CPU autocast.
+        # See https://github.com/pytorch/pytorch/issues/110966.
+        if bias.device.type == "cuda" and torch.is_autocast_enabled():
+            target_dtype = torch.get_autocast_gpu_dtype()
+        elif bias.device.type == "cpu" and torch.is_autocast_cpu_enabled():
+            target_dtype = torch.get_autocast_cpu_dtype()
+        if bias.dtype != target_dtype:
+            bias = bias.to(target_dtype)
+            ensure_finite_(bias, check_neg_inf=True, check_pos_inf=False)
+        return bias
+
+    def _scaled_dot_product_attention(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        attn_mask: Optional[torch.Tensor] = None,
+        dropout_p: float = 0.0,
+        is_causal: bool = False,
+    ) -> torch.Tensor:
+        """
+        Computes scaled dot product attention on query, key and value tensors, using an optional
+        attention mask if passed, and applying dropout if a probability greater than 0.0 is specified.
+        """
+        if self.flash_attn_func is not None and attn_mask is None:
+            r = self.flash_attn_func(
+                q.transpose(1, 2),
+                k.transpose(1, 2),
+                v.transpose(1, 2),
+                dropout_p=dropout_p,
+                causal=False,
+            )
+            return r.transpose(1, 2)
+        else:
+            # torch's sdpa doesn't support GQA, so we're doing this
+            assert k.size(1) == v.size(1)
+            num_kv_heads = k.size(1)
+            num_q_heads = q.size(1)
+            if num_q_heads != num_kv_heads:
+                assert num_q_heads % num_kv_heads == 0
+                k = k.repeat_interleave(
+                    num_q_heads // num_kv_heads, dim=1, output_size=num_q_heads
+                )
+                v = v.repeat_interleave(
+                    num_q_heads // num_kv_heads, dim=1, output_size=num_q_heads
+                )
+
+            # Modify: MDM set causal to False, and with no attn_mask.
+            return scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=attn_mask,
+                dropout_p=dropout_p,
+                is_causal=False,
+            )
+
+    def attention(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
+        attention_bias: Optional[torch.Tensor] = None,
+        layer_past: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        use_cache: bool = False,
+        replace_position: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, Optional[Tuple[torch.Tensor, torch.Tensor]]]:
+        B, T, C = q.size()  # batch size, sequence length, d_model
+        dtype = k.dtype
+
+        # Optionally apply layer norm to keys and queries.
+        if (
+            self.q_norm is not None and self.k_norm is not None
+        ):  # self.q_norm: None, self.k_norm: None
+            q = self.q_norm(q).to(dtype=dtype)
+            k = self.k_norm(k).to(dtype=dtype)
+
+        # Move head forward to be next to the batch dim.
+        # shape: (B, nh, T, hs)
+        # self.config.n_heads: 32
+        q = q.view(B, T, self.config.n_heads, C // self.config.n_heads).transpose(1, 2)
+        # shape: (B, n_kv_h, T, hs)
+        k = k.view(
+            B, T, self.config.effective_n_kv_heads, C // self.config.n_heads
+        ).transpose(1, 2)
+        # shape: (B, n_kv_h, T, hs)
+        v = v.view(
+            B, T, self.config.effective_n_kv_heads, C // self.config.n_heads
+        ).transpose(1, 2)
+
+        if layer_past is not None:
+            past_key, past_value = layer_past
+            if replace_position is None:
+                k = torch.cat((past_key, k), dim=-2)
+                v = torch.cat((past_value, v), dim=-2)
+            else:
+                # k shape is [B, n_kv_h, selected_length, hs]
+                # replace_position shape is [B, L], where L contains 0s and 1s, 0 means no replacement, 1 means replace, with selected_length number of 1s
+                # past_key shape is [B, n_kv_h, L, hs]
+                # Replace selected_length number of 1s in past_key with k
+
+                # Handle batched replace_position correctly
+                B = replace_position.shape[0]
+                for batch_idx in range(B):
+                    # Get indices for this batch
+                    batch_replace_indices = replace_position[batch_idx].nonzero(
+                        as_tuple=True
+                    )[0]
+                    if len(batch_replace_indices) > 0:
+                        # Replace positions in past_key and past_value for this batch
+                        past_key[batch_idx, :, batch_replace_indices] = k[
+                            batch_idx, :, : len(batch_replace_indices)
+                        ]
+                        past_value[batch_idx, :, batch_replace_indices] = v[
+                            batch_idx, :, : len(batch_replace_indices)
+                        ]
+
+                k = past_key
+                v = past_value
+
+        present = (k, v) if use_cache else None  # present: None
+        query_len, key_len = (
+            q.shape[-2],
+            k.shape[-2],
+        )  # could be different if layer_past not None
+
+        if self.config.rope:
+            # Apply rotary embeddings.
+            if replace_position is None:
+                q, k = self.rotary_emb(q, k)
+            else:
+                # For batched replace_position, use the maximum position across all batches
+                max_replace_pos = (
+                    replace_position.nonzero(as_tuple=True)[1].max() + 1
+                    if replace_position.any()
+                    else key_len
+                )
+                q, k = self.rotary_emb(q, k, max_replace_pos)
+
+        if attention_bias is not None:
+            # Resize and cast attention bias.
+            # The current dtype of the attention bias might not match the dtype that the SDP attn function will
+            # run in if AMP is enabled, and this can be a problem if some tokens are masked out due to padding
+            # as down-casting the attention bias to the autocast precision will result in -infs, which will
+            # cause the SDP attn function to produce NaNs.
+            attention_bias = self._cast_attn_bias(
+                attention_bias[:, :, key_len - query_len : key_len, :key_len], dtype
+            )
+
+        # Get the attention scores.
+        # shape: (B, nh, T, hs)
+        att = self._scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=None,
+            dropout_p=0.0 if not self.training else self.config.attention_dropout,
+            is_causal=False,
+        )
+        # Re-assemble all head outputs side-by-side.
+        att = att.transpose(1, 2).contiguous().view(B, T, C)
+
+        # Apply output projection.
+        return self.attn_out(att), present
+
+    @abstractmethod
+    def forward(
+        self,
+        x: torch.Tensor,
+        attention_bias: Optional[torch.FloatTensor] = None,
+        layer_past: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        use_cache: bool = False,
+    ) -> Tuple[torch.Tensor, Optional[Tuple[torch.Tensor, torch.Tensor]]]:
+        raise NotImplementedError
+
+    @classmethod
+    def build(
+        cls, layer_id: int, config: ModelConfig, cache: BufferCache
+    ) -> InfoGainLLaDABlock:
+        if config.block_type == BlockType.sequential:
+            return InfoGainLLaDASequentialBlock(layer_id, config, cache)
+        elif config.block_type == BlockType.llama:
+            return InfoGainLLaDALlamaBlock(layer_id, config, cache)
+        else:
+            raise NotImplementedError(f"Unknown block type: '{config.block_type}'")
+
+
+class InfoGainLLaDASequentialBlock(InfoGainLLaDABlock):
+    """
+    This is a typical transformer block where the output is computed as ``MLP(LN(x + Attention(LN(x))))``
+    (plus another skip connection).
+    """
+
+    def __init__(self, layer_id: int, config: ModelConfig, cache: BufferCache):
+        super().__init__(layer_id, config, cache)
+        # Layer norms.
+        self.attn_norm = LayerNorm.build(config)
+        self.ff_norm = LayerNorm.build(config)
+        # Attention input projection. Projects x -> (q, k, v)
+        head_dim = config.d_model // config.n_heads
+        self.fused_dims = (
+            config.d_model,
+            config.effective_n_kv_heads * head_dim,
+            config.effective_n_kv_heads * head_dim,
+        )
+        self.att_proj = nn.Linear(
+            config.d_model,
+            sum(self.fused_dims),
+            bias=config.include_bias | config.include_qkv_bias,
+            device=config.init_device,
+        )
+        # Feed-forward input projection.
+        self.ff_proj = nn.Linear(
+            config.d_model,
+            self.hidden_size,
+            bias=config.include_bias,
+            device=config.init_device,
+        )
+
+    def reset_parameters(self):
+        super().reset_parameters()
+        self.attn_norm.reset_parameters()
+        self.ff_norm.reset_parameters()
+        # NOTE: the standard deviation for these weights does not depend on the layer.
+        init_weights(
+            self.config,
+            self.att_proj,
+            d=self.config.d_model,
+            layer_id=None,
+            type_of_module=ModuleType.in_module,
+        )
+        init_weights(
+            self.config,
+            self.ff_proj,
+            d=self.config.d_model,
+            layer_id=None,
+            type_of_module=ModuleType.in_module,
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        attention_bias: Optional[torch.Tensor] = None,
+        layer_past: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        use_cache: bool = False,
+    ) -> Tuple[torch.Tensor, Optional[Tuple[torch.Tensor, torch.Tensor]]]:
+        # Get query, key, value projections.
+        # shape:
+        #  - for regular attn q, k, v: (batch_size, seq_len, d_model)
+        #  - for multi-query attn q: (batch_size, seq_len, d_model)
+        #                      k, v: (batch_size, seq_len, d_model // n_heads)
+        #  - for group query attn q: (batch_size, seq_len, d_model)
+        #                      k, v: (batch_size, seq_len, d_model // n_kv_heads)
+        if self._activation_checkpoint_fn is not None:
+            q, k, v = self.att_proj(
+                self._activation_checkpoint_fn(self.attn_norm, x)
+            ).split(self.fused_dims, dim=-1)
+        else:
+            q, k, v = self.att_proj(self.attn_norm(x)).split(self.fused_dims, dim=-1)
+
+        # Get attention scores.
+        if self._activation_checkpoint_fn is not None:
+            att, cache = self._activation_checkpoint_fn(  # type: ignore
+                self.attention,
+                q,
+                k,
+                v,
+                attention_bias,
+                layer_past=layer_past,
+                use_cache=use_cache,
+            )
+        else:
+            att, cache = self.attention(
+                q, k, v, attention_bias, layer_past=layer_past, use_cache=use_cache
+            )
+
+        # Add attention scores.
+        # shape: (B, T, C)
+        x = x + self.dropout(att)
+
+        # Add feed-forward projection.
+        # shape: (batch_size, seq_len, d_model)
+        og_x = x
+        if self._activation_checkpoint_fn is not None:
+            x = self._activation_checkpoint_fn(self.ff_norm, x)  # type: ignore
+        else:
+            x = self.ff_norm(x)
+        x = self.ff_proj(x)
+        if self._activation_checkpoint_fn is not None:
+            x = self._activation_checkpoint_fn(self.act, x)  # type: ignore
+        else:
+            x = self.act(x)
+        x = self.ff_out(x)
+        x = self.dropout(x)
+        x = og_x + x
+
+        return x, cache
+
+
+class InfoGainLLaDALlamaBlock(InfoGainLLaDABlock):
+    """
+    This is a transformer block where the output is computed as ``MLP(LN(x + Attention(LN(x))))``
+    (plus another skip connection). This block is similar to `InfoGainLLaDASequentialBlock`
+    but some operations have slightly different implementations to imitate the
+    behavior of Llama.
+    """
+
+    def __init__(self, layer_id: int, config: ModelConfig, cache: BufferCache):
+        super().__init__(layer_id, config, cache)
+        # Layer norms.
+        self.attn_norm = LayerNorm.build(config)
+        self.ff_norm = LayerNorm.build(config)
+        self.__cache = cache
+
+        # Attention input projection. Projects x -> (q, k, v)
+        head_dim = config.d_model // config.n_heads
+        q_proj_out_dim = config.d_model
+        k_proj_out_dim = config.effective_n_kv_heads * head_dim
+        v_proj_out_dim = config.effective_n_kv_heads * head_dim
+        self.q_proj = nn.Linear(
+            config.d_model,
+            q_proj_out_dim,
+            bias=config.include_bias | config.include_qkv_bias,
+            device=config.init_device,
+        )
+        self.k_proj = nn.Linear(
+            config.d_model,
+            k_proj_out_dim,
+            bias=config.include_bias | config.include_qkv_bias,
+            device=config.init_device,
+        )
+        self.v_proj = nn.Linear(
+            config.d_model,
+            v_proj_out_dim,
+            bias=config.include_bias | config.include_qkv_bias,
+            device=config.init_device,
+        )
+
+        # Feed-forward input projection.
+        self.ff_proj = nn.Linear(
+            config.d_model,
+            self.hidden_size,
+            bias=config.include_bias,
+            device=config.init_device,
+        )
+        # new add
+        self.up_proj = nn.Linear(
+            config.d_model,
+            self.hidden_size,
+            bias=config.include_bias,
+            device=config.init_device,
+        )
+
+    def reset_parameters(self):
+        super().reset_parameters()
+        self.attn_norm.reset_parameters()
+        self.ff_norm.reset_parameters()
+        # NOTE: the standard deviation for these weights does not depend on the layer.
+        init_weights(self.config, self.q_proj, d=self.config.d_model, layer_id=None)
+        init_weights(self.config, self.k_proj, d=self.config.d_model, layer_id=None)
+        init_weights(self.config, self.v_proj, d=self.config.d_model, layer_id=None)
+        init_weights(self.config, self.ff_proj, d=self.config.d_model, layer_id=None)
+        init_weights(
+            self.config, self.up_proj, d=self.config.d_model, layer_id=None
+        )  # new add
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        attention_bias: Optional[torch.Tensor] = None,
+        layer_past: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        use_cache: bool = False,
+        replace_position: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, Optional[Tuple[torch.Tensor, torch.Tensor]]]:
+        # Get query, key, value projections.
+        # shape:
+        #  - for regular attn q, k, v: (batch_size, seq_len, d_model)
+        #  - for multi-query attn q: (batch_size, seq_len, d_model)
+        #                      k, v: (batch_size, seq_len, d_model // n_heads)
+        #  - for group query attn q: (batch_size, seq_len, d_model)
+        #                      k, v: (batch_size, seq_len, d_model // n_kv_heads)
+        x_normed = self.attn_norm(x)  # x:torch.Size([2, 168, 4096])
+        q = self.q_proj(x_normed)  # q:torch.Size([2, 168, 4096])
+        k = self.k_proj(x_normed)  # k:torch.Size([2, 168, 4096])
+        v = self.v_proj(x_normed)  # v:torch.Size([2, 168, 4096])
+        # attention_bias: None
+        # layer_past: None
+        # use_cache: False
+        # Get attention scores.
+        if self._activation_checkpoint_fn is not None:
+            att, cache = self._activation_checkpoint_fn(  # type: ignore
+                self.attention,
+                q,
+                k,
+                v,
+                attention_bias,
+                layer_past=layer_past,
+                use_cache=use_cache,
+                replace_position=replace_position,
+            )
+        else:
+            att, cache = self.attention(
+                q,
+                k,
+                v,
+                attention_bias,
+                layer_past=layer_past,
+                use_cache=use_cache,
+                replace_position=replace_position,
+            )
+
+        # Add attention scores.
+        # shape: (B, T, C)
+        x = x + self.dropout(att)
+
+        # Add feed-forward projection.
+        # shape: (batch_size, seq_len, d_model)
+        og_x = x
+        if self._activation_checkpoint_fn is not None:
+            x = self._activation_checkpoint_fn(self.ff_norm, x)  # type: ignore
+        else:
+            x = self.ff_norm(x)
+        x, x_up = self.ff_proj(x), self.up_proj(x)  # new add
+        if self._activation_checkpoint_fn is not None:
+            x = self._activation_checkpoint_fn(self.act, x)  # type: ignore
+        else:
+            x = self.act(x)
+        x = x * x_up  # new add
+        x = self.ff_out(x)
+        x = self.dropout(x)
+        x = og_x + x
+
+        return x, cache
+
+
+class InfoGainLLaDABlockDiffBlock(InfoGainLLaDABlock):
+    """
+    This is a transformer block where the output is computed as ``MLP(LN(x + Attention(LN(x))))``
+    (plus another skip connection). This block is similar to `InfoGainLLaDASequentialBlock`
+    but some operations have slightly different implementations to imitate the
+    behavior of Llama.
+    """
+
+    def __init__(self, layer_id: int, config: ModelConfig, cache: BufferCache):
+        super().__init__(layer_id, config, cache)
+        # Layer norms.
+        self.attn_norm = LayerNorm.build(config)
+        self.ff_norm = LayerNorm.build(config)
+        self.__cache = cache
+
+        # Attention input projection. Projects x -> (q, k, v)
+        head_dim = config.d_model // config.n_heads
+        q_proj_out_dim = config.d_model
+        k_proj_out_dim = config.effective_n_kv_heads * head_dim
+        v_proj_out_dim = config.effective_n_kv_heads * head_dim
+        self.q_proj = nn.Linear(
+            config.d_model,
+            q_proj_out_dim,
+            bias=config.include_bias | config.include_qkv_bias,
+            device=config.init_device,
+        )
+        self.k_proj = nn.Linear(
+            config.d_model,
+            k_proj_out_dim,
+            bias=config.include_bias | config.include_qkv_bias,
+            device=config.init_device,
+        )
+        self.v_proj = nn.Linear(
+            config.d_model,
+            v_proj_out_dim,
+            bias=config.include_bias | config.include_qkv_bias,
+            device=config.init_device,
+        )
+
+        # Feed-forward input projection.
+        self.ff_proj = nn.Linear(
+            config.d_model,
+            self.hidden_size,
+            bias=config.include_bias,
+            device=config.init_device,
+        )
+        # new add
+        self.up_proj = nn.Linear(
+            config.d_model,
+            self.hidden_size,
+            bias=config.include_bias,
+            device=config.init_device,
+        )
+
+    def reset_parameters(self):
+        super().reset_parameters()
+        self.attn_norm.reset_parameters()
+        self.ff_norm.reset_parameters()
+        # NOTE: the standard deviation for these weights does not depend on the layer.
+        init_weights(self.config, self.q_proj, d=self.config.d_model, layer_id=None)
+        init_weights(self.config, self.k_proj, d=self.config.d_model, layer_id=None)
+        init_weights(self.config, self.v_proj, d=self.config.d_model, layer_id=None)
+        init_weights(self.config, self.ff_proj, d=self.config.d_model, layer_id=None)
+        init_weights(
+            self.config, self.up_proj, d=self.config.d_model, layer_id=None
+        )  # new add
+
+    def cross_attn_flex(self, qkv, mask=None):
+        qkv = rearrange(qkv, "b s three h d -> b h three s d", h=self.n_heads)
+        x = fused_flex_attention(qkv[:, :, 0], qkv[:, :, 1], qkv[:, :, 2], mask=mask)
+        x = rearrange(x, "b h s d -> b s (h d)")
+        return x
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        attention_bias: Optional[torch.Tensor] = None,
+        layer_past: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        use_cache: bool = False,
+    ) -> Tuple[torch.Tensor, Optional[Tuple[torch.Tensor, torch.Tensor]]]:
+        # Get query, key, value projections.
+        # shape:
+        #  - for regular attn q, k, v: (batch_size, seq_len, d_model)
+        #  - for multi-query attn q: (batch_size, seq_len, d_model)
+        #                      k, v: (batch_size, seq_len, d_model // n_heads)
+        #  - for group query attn q: (batch_size, seq_len, d_model)
+        #                      k, v: (batch_size, seq_len, d_model // n_kv_heads)
+        x_normed = self.attn_norm(x)
+        q = self.q_proj(x_normed)
+        k = self.k_proj(x_normed)
+        v = self.v_proj(x_normed)
+
+        # Get attention scores.
+        if self._activation_checkpoint_fn is not None:
+            att, cache = self._activation_checkpoint_fn(  # type: ignore
+                self.attention,
+                q,
+                k,
+                v,
+                attention_bias,
+                layer_past=layer_past,
+                use_cache=use_cache,
+            )
+        else:
+            att, cache = self.attention(
+                q, k, v, attention_bias, layer_past=layer_past, use_cache=use_cache
+            )
+
+        # Add attention scores.
+        # shape: (B, T, C)
+        x = x + self.dropout(att)
+
+        # Add feed-forward projection.
+        # shape: (batch_size, seq_len, d_model)
+        og_x = x
+        if self._activation_checkpoint_fn is not None:
+            x = self._activation_checkpoint_fn(self.ff_norm, x)  # type: ignore
+        else:
+            x = self.ff_norm(x)
+        x, x_up = self.ff_proj(x), self.up_proj(x)  # new add
+        if self._activation_checkpoint_fn is not None:
+            x = self._activation_checkpoint_fn(self.act, x)  # type: ignore
+        else:
+            x = self.act(x)
+        x = x * x_up  # new add
+        x = self.ff_out(x)
+        x = self.dropout(x)
+        x = og_x + x
+
+        return x, cache
+
+
+class InfoGainLLaDAOutput(NamedTuple):
+    logits: torch.FloatTensor
+    """
+    A tensor of shape `(batch_size, seq_len, vocab_size)` representing the log probabilities
+    for the next token *before* normalization via (log) softmax.
+    """
+
+    attn_key_values: Optional[List[Tuple[torch.Tensor, torch.Tensor]]]
+    """
+    Attention keys and values from each block.
+    """
+
+    hidden_states: Optional[Tuple[torch.Tensor]]
+    """
+    Hidden states from each block.
+    """
+
+
+class InfoGainLLaDAGenerateOutput(NamedTuple):
+    token_ids: torch.LongTensor
+    """
+    The generated token IDs, a tensor of shape `(batch_size, beam_size, max_steps)`.
+    These do *not* include the original input IDs.
+    """
+
+    scores: torch.FloatTensor
+    """
+    The scores of the generated sequences, a tensor of shape `(batch_size, beam_size)`.
+    """
+
+
+class InfoGainLLaDABlockGroup(nn.ModuleList):
+    def __init__(
+        self,
+        config: ModelConfig,
+        layer_offset: int,
+        modules: Optional[Iterable[nn.Module]] = None,
+    ):
+        super().__init__(modules)
+        self.config = config
+        self.layer_offset = layer_offset
+        self.activation_checkpointing_strategy: Optional[
+            ActivationCheckpointingStrategy
+        ] = None
+        self._activation_checkpoint_fn = activation_checkpoint_function(self.config)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        attention_bias: Optional[torch.FloatTensor] = None,
+        layers_past: Optional[List[Tuple[torch.Tensor, torch.Tensor]]] = None,
+        use_cache: bool = False,
+    ) -> Tuple[torch.Tensor, Optional[List[Tuple[torch.Tensor, torch.Tensor]]]]:
+        attn_key_values: Optional[List[Tuple[torch.Tensor, torch.Tensor]]] = (
+            [] if use_cache else None
+        )
+        for block_idx, block in enumerate(self):
+            layer_past = None if layers_past is None else layers_past[block_idx]
+            block_idx += self.layer_offset
+            if (
+                (
+                    self.activation_checkpointing_strategy
+                    == ActivationCheckpointingStrategy.whole_layer
+                )
+                or (
+                    self.activation_checkpointing_strategy
+                    == ActivationCheckpointingStrategy.one_in_two
+                    and block_idx % 2 == 0
+                )
+                or (
+                    self.activation_checkpointing_strategy
+                    == ActivationCheckpointingStrategy.one_in_three
+                    and block_idx % 3 == 0
+                )
+                or (
+                    self.activation_checkpointing_strategy
+                    == ActivationCheckpointingStrategy.one_in_four
+                    and block_idx % 4 == 0
+                )
+            ):
+                # shape: (batch_size, seq_len, d_model)
+                x, cache = self._activation_checkpoint_fn(  # type: ignore
+                    block,
+                    x,
+                    attention_bias=attention_bias,
+                    layer_past=layer_past,
+                    use_cache=use_cache,
+                )
+            else:
+                # shape: (batch_size, seq_len, d_model)
+                x, cache = block(
+                    x,
+                    attention_bias=attention_bias,
+                    layer_past=layer_past,
+                    use_cache=use_cache,
+                )
+            if attn_key_values is not None:
+                assert cache is not None
+                attn_key_values.append(cache)
+        return x, attn_key_values
+
+    def reset_parameters(self):
+        for block in self:
+            block.reset_parameters()
+
+    def set_activation_checkpointing(
+        self, strategy: Optional[ActivationCheckpointingStrategy]
+    ):
+        self.activation_checkpointing_strategy = strategy
+        for block in self:
+            block.set_activation_checkpointing(strategy)
+
+
+class InfoGainLLaDAModel(nn.Module):
+    def __init__(self, config: ModelConfig, init_params: bool = True):
+        super().__init__()
+        self.config = config
+        self.__cache = BufferCache()
+
+        # Validate config.
+        if self.config.alibi and self.config.flash_attention:
+            raise Exception("ALiBi is currently not supported with FlashAttention")
+
+        if self.config.alibi and self.config.rope:
+            raise Exception("ALiBi and RoPE are mutually exclusive")
+
+        if (
+            self.config.embedding_size is not None
+            and self.config.embedding_size != self.config.vocab_size
+        ):
+            if self.config.embedding_size < self.config.vocab_size:
+                raise Exception(
+                    "embedding size should be at least as big as vocab size"
+                )
+            elif self.config.embedding_size % 128 != 0:
+                import warnings
+
+                warnings.warn(
+                    "Embedding size is not a multiple of 128! This could hurt throughput performance.",
+                    UserWarning,
+                )
+
+        self.activation_checkpointing_strategy: Optional[
+            ActivationCheckpointingStrategy
+        ] = None
+        self._activation_checkpoint_fn: Callable = activation_checkpoint_function(
+            self.config
+        )
+
+        if not (
+            0 < self.config.block_group_size <= self.config.n_layers
+            and self.config.n_layers % self.config.block_group_size == 0
+        ):
+            raise Exception("n layers must be divisible by block group size")
+
+        torch.backends.cuda.enable_flash_sdp(True)
+        torch.backends.cuda.enable_mem_efficient_sdp(
+            False
+        )  # this is super slow so make sure torch won't use it
+
+        self.transformer = nn.ModuleDict(
+            dict(
+                wte=nn.Embedding(
+                    config.embedding_size or config.vocab_size,
+                    config.d_model,
+                    device=config.init_device,
+                ),
+                emb_drop=Dropout(config.embedding_dropout),
+                ln_f=LayerNorm.build(config),
+            )
+        )
+
+        blocks = [
+            InfoGainLLaDABlock.build(i, config, self.__cache)
+            for i in range(config.n_layers)
+        ]
+        if self.config.block_group_size > 1:
+            block_groups = [
+                InfoGainLLaDABlockGroup(
+                    config, i, blocks[i : i + config.block_group_size]
+                )
+                for i in range(0, config.n_layers, config.block_group_size)
+            ]
+            self.transformer.update({"block_groups": nn.ModuleList(block_groups)})
+        else:
+            self.transformer.update({"blocks": nn.ModuleList(blocks)})
+
+        if not (self.config.alibi or self.config.rope):
+            self.transformer.update(
+                {
+                    "wpe": nn.Embedding(
+                        config.max_sequence_length,
+                        config.d_model,
+                        device=config.init_device,
+                    )
+                }
+            )
+        if not config.weight_tying:
+            self.transformer.update(
+                {
+                    "ff_out": nn.Linear(
+                        config.d_model,
+                        config.embedding_size or config.vocab_size,
+                        bias=config.include_bias,
+                        device=config.init_device,
+                    )
+                }
+            )
+        # When `init_device="meta"` FSDP will call `reset_parameters()` to initialize weights.
+        if init_params and self.config.init_device != "meta":
+            self.reset_parameters()
+        self.__num_fwd_flops: Optional[int] = None
+        # Warm up cache.
+        if self.config.alibi:
+            get_causal_attention_bias(
+                self.__cache, config.max_sequence_length, _non_meta_init_device(config)
+            )
+            self.get_alibi_attention_bias(
+                config.max_sequence_length, _non_meta_init_device(config)
+            )
+
+    def set_activation_checkpointing(
+        self, strategy: Optional[ActivationCheckpointingStrategy]
+    ):
+        self.activation_checkpointing_strategy = strategy
+        if self.config.block_group_size != 1:
+            for block_group in self.transformer.block_groups:
+                block_group.set_activation_checkpointing(strategy)
+        else:
+            for block in self.transformer.blocks:
+                block.set_activation_checkpointing(strategy)
+
+    @property
+    def device(self) -> torch.device:
+        device: torch.device = self.transformer.wte.weight.device  # type: ignore
+        if device.type == "meta":
+            return _non_meta_init_device(self.config)
+        else:
+            return device
+
+    def reset_parameters(self):
+        log.info("Initializing model parameters...")
+        # Top-level embeddings / linear layers.
+        init_weights(
+            self.config,
+            self.transformer.wte,  # type: ignore
+            std_factor=(
+                (0.5 * math.sqrt(self.config.d_model))
+                if self.config.scale_logits
+                else 1.0
+            ),
+            type_of_module=ModuleType.emb,
+        )
+        if hasattr(self.transformer, "wpe"):
+            init_weights(self.config, self.transformer.wpe, type_of_module=ModuleType.emb)  # type: ignore
+
+        # Top-level layer norm.
+        self.transformer.ln_f.reset_parameters()  # type: ignore
+
+        # Output weights.
+        if hasattr(self.transformer, "ff_out"):
+            init_weights(self.config, self.transformer.ff_out, type_of_module=ModuleType.final_out)  # type: ignore
+
+        # Let the blocks handle themselves.
+        if self.config.block_group_size == 1:
+            for block in self.transformer.blocks:
+                block.reset_parameters()
+        else:
+            for block_group in self.transformer.block_groups:
+                block_group.reset_parameters()
+
+    def get_alibi_attention_bias(
+        self, seq_len: int, device: torch.device
+    ) -> torch.Tensor:
+        if (
+            alibi_bias := self.__cache.get("alibi_attention_bias")
+        ) is not None and alibi_bias.shape[-1] >= seq_len:
+            if alibi_bias.device != device:
+                alibi_bias = alibi_bias.to(device)
+                self.__cache["alibi_attention_bias"] = alibi_bias
+            return alibi_bias
+        with torch.autocast(device.type, enabled=False):
+            alibi_bias = alibi_attention_bias(seq_len, self.config, device)
+        self.__cache["alibi_attention_bias"] = alibi_bias
+        return alibi_bias
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor,
+        input_embeddings: Optional[torch.FloatTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        attention_bias: Optional[torch.Tensor] = None,
+        past_key_values: Optional[Sequence[Tuple[torch.Tensor, torch.Tensor]]] = None,
+        use_cache: bool = False,
+        last_logits_only: bool = False,
+        output_hidden_states: Optional[bool] = None,
+        replace_position: Optional[torch.Tensor] = None,
+    ) -> InfoGainLLaDAOutput:
+        """
+        :param input_ids: A tensor of shape `(batch_size, seq_len)`.
+        :param input_embeddings: A tensor of shape `(batch_size, seq_len, d_model)` with input
+            embeddings. When provided, it is treated as the output of the input embedding layer.
+        :param attention_mask: A tensor of shape `(batch_size, seq_len)` that indicates
+            which input IDs are masked. A `1` value in the mask means that
+            the corresponding input ID should *not* be ignored. A `0` means
+            that the corresponding input ID is masked.
+
+            This has the same meaning as the `attention_mask` in HuggingFace's `transformers`
+            library.
+        :param attention_bias: A tensor of shape `(batch_size, 1, seq_len, seq_len)`,
+            `(1, 1, seq_len, seq_len)`, or `(seq_len, seq_len)`. This is used
+            to introduce causal or other biases.
+
+            If the tensor is a bool or byte tensor, a `True` or `1` at `attention_bias[:, :, i, j]`
+            indicates that the i-th element in the sequence is allowed to attend to the j-th
+            element in the sequence.
+
+            If the tensor is a float tensor, it will just be added to the attention
+            scores before the softmax.
+
+            The default is causal, which corresponds to a lower-diagonal byte matrix of ones.
+        :param past_key_values: Pre-computed keys and values for each attention block.
+            Can be used to speed up sequential decoding. The `input_ids` which have
+            their past given to this model should not be passed as `input_ids` as they have already been computed.
+        :param use_cache: If `True`, return key and value tensors for each block.
+        :param last_logits_only: If `True`, only compute the logits for the last token of each sequence.
+            This can speed up decoding when you only care about the next token.
+        """
+        # Add Basic MDM Model config check
+        assert (
+            not self.config.alibi
+        ), "Alibi length extrapolation is not supported for MDM."
+        assert self.config.rope, "Rope must be used in Llama-Encoder for MDM."
+        # assert (past_key_values is None and not use_cache), "The kvcache is not suppotred for MDM."
+
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else False
+        )
+
+        if past_key_values:
+            assert len(past_key_values) == self.config.n_layers
+
+        batch_size, seq_len = (
+            input_ids.size()
+            if input_embeddings is None
+            else input_embeddings.size()[:2]
+        )
+        if past_key_values is None:
+            past_length = 0
+        else:
+            past_length = past_key_values[0][0].size(-2)
+
+        # Get embeddings of input.
+        # shape: (batch_size, seq_len, d_model)
+        x = self.transformer.wte(input_ids) if input_embeddings is None else input_embeddings  # type: ignore
+
+        if self.config.input_emb_norm:
+            x = x * (self.config.d_model**0.5)
+
+        if not (self.config.alibi or self.config.rope):
+            # Get positional embeddings.
+            # shape: (1, seq_len)
+            pos = torch.arange(
+                past_length, past_length + seq_len, dtype=torch.long, device=x.device
+            ).unsqueeze(0)
+            # shape: (1, seq_len, d_model)
+            pos_emb = self.transformer.wpe(pos)  # type: ignore
+            x = pos_emb + x
+
+        # Add input + positional embeddings and apply dropout.
+        # shape: (batch_size, seq_len, d_model)
+        x = self.transformer.emb_drop(x)  # type: ignore
+
+        # Transform the attention mask into what the blocks expect.
+        if attention_mask is not None and 0.0 in attention_mask:
+            # shape: (batch_size, 1, 1, seq_len)
+            attention_mask = attention_mask.to(dtype=torch.float).view(batch_size, -1)[
+                :, None, None, :
+            ]
+            attention_mask = (1.0 - attention_mask) * torch.finfo(
+                attention_mask.dtype
+            ).min
+        else:
+            attention_mask = None
+
+        # Merge attention mask with attention bias.
+        if (
+            attention_bias is not None
+            or attention_mask is not None
+            or self.config.alibi
+            # NOTE (epwalsh): we need to initialize the attn bias in order for attn to work properly
+            # with key+value cache. Otherwise `F.scaled_dot_product_attention()` doesn't seem to compute
+            # scores correctly.
+            or past_key_values is not None
+        ):
+            if attention_bias is None and self.config.alibi:
+                attention_bias = get_causal_attention_bias(
+                    self.__cache, past_length + seq_len, x.device
+                ) + self.get_alibi_attention_bias(past_length + seq_len, x.device)
+            elif attention_bias is None:
+                attention_bias = get_causal_attention_bias(
+                    self.__cache, past_length + seq_len, x.device
+                )
+            elif attention_bias.dtype in (torch.int8, torch.bool):
+                attention_bias = attention_bias.to(dtype=torch.float)
+                attention_bias.masked_fill_(
+                    attention_bias == 0.0, torch.finfo(attention_bias.dtype).min
+                )
+
+            # Transform to the right shape and data type.
+            mask_len = seq_len
+            if attention_mask is not None:
+                mask_len = attention_mask.shape[-1]
+            elif past_key_values is not None:
+                mask_len = past_key_values[0][0].shape[-2] + seq_len
+            attention_bias = attention_bias[:, :, :mask_len, :mask_len].to(
+                dtype=torch.float
+            )
+
+            # Add in the masking bias.
+            if attention_mask is not None:
+                attention_bias = attention_bias + attention_mask
+                # Might get -infs after adding attention mask, since dtype.min + dtype.min = -inf.
+                # `F.scaled_dot_product_attention()` doesn't handle -inf like you'd expect, instead
+                # it can produce NaNs.
+                ensure_finite_(attention_bias, check_neg_inf=True, check_pos_inf=False)
+
+        attn_key_values: Optional[List[Tuple[torch.Tensor, torch.Tensor]]] = (
+            [] if use_cache else None
+        )
+
+        # decoder layers
+        all_hidden_states = []
+
+        # Apply blocks one-by-one.
+        if self.config.block_group_size == 1:
+            for block_idx, block in enumerate(self.transformer.blocks):
+                if output_hidden_states:
+                    # add hidden states
+                    all_hidden_states.append(x)
+
+                layer_past = (
+                    None if past_key_values is None else past_key_values[block_idx]
+                )
+                if (
+                    (
+                        self.activation_checkpointing_strategy
+                        == ActivationCheckpointingStrategy.whole_layer
+                    )
+                    or (
+                        self.activation_checkpointing_strategy
+                        == ActivationCheckpointingStrategy.one_in_two
+                        and block_idx % 2 == 0
+                    )
+                    or (
+                        self.activation_checkpointing_strategy
+                        == ActivationCheckpointingStrategy.one_in_three
+                        and block_idx % 3 == 0
+                    )
+                    or (
+                        self.activation_checkpointing_strategy
+                        == ActivationCheckpointingStrategy.one_in_four
+                        and block_idx % 4 == 0
+                    )
+                ):
+                    # shape: (batch_size, seq_len, d_model)
+                    x, cache = self._activation_checkpoint_fn(
+                        block,
+                        x,
+                        attention_bias=attention_bias,
+                        layer_past=layer_past,
+                        use_cache=use_cache,
+                        replace_position=replace_position,
+                    )
+                else:
+                    # shape: (batch_size, seq_len, d_model)
+                    x, cache = block(
+                        x,
+                        attention_bias=attention_bias,
+                        layer_past=layer_past,
+                        use_cache=use_cache,
+                        replace_position=replace_position,
+                    )
+                if attn_key_values is not None:
+                    assert cache is not None
+                    attn_key_values.append(cache)
+        else:
+            for group_idx, block_group in enumerate(self.transformer.block_groups):
+                if output_hidden_states:
+                    # add hidden states
+                    all_hidden_states.append(x)
+
+                layers_past = (
+                    None
+                    if past_key_values is None
+                    else past_key_values[
+                        group_idx
+                        * self.config.block_group_size : (group_idx + 1)
+                        * self.config.block_group_size
+                    ]
+                )
+                x, cache = block_group(
+                    x,
+                    attention_bias=attention_bias,
+                    layers_past=layers_past,
+                    use_cache=use_cache,
+                )
+                if attn_key_values is not None:
+                    assert cache is not None
+                    attn_key_values.extend(cache)
+
+        if last_logits_only:
+            # shape: (batch_size, 1, d_model)
+            x = x[:, -1, :].unsqueeze(1)
+
+        # Apply final layer norm.
+        # shape: (batch_size, seq_len or 1, d_model)
+        x = self.transformer.ln_f(x)  # type: ignore
+        if output_hidden_states:
+            # add final hidden state post-final-layernorm, following HuggingFace's convention
+            all_hidden_states.append(x)
+
+        # Get logits.
+        # shape: (batch_size, seq_len or 1, vocab_size)
+        if self.config.weight_tying:
+            logits = F.linear(x, self.transformer.wte.weight, None)  # type: ignore
+        else:
+            logits = self.transformer.ff_out(x)  # type: ignore
+        if self.config.scale_logits:
+            logits.mul_(1 / math.sqrt(self.config.d_model))
+
+        return InfoGainLLaDAOutput(logits=logits, attn_key_values=attn_key_values, hidden_states=tuple(all_hidden_states) if output_hidden_states else None)  # type: ignore[arg-type]
+
+
+def create_model_config_from_pretrained_config(
+    config: Union[InfoGainLLaDAConfig, LLaDAConfig],
+):
+    """
+    Utility function
+    """
+
+    kwargs = {}
+    for field in fields(ModelConfig):
+        kwargs[field.name] = getattr(config, field.name)
+
+    model_config = ModelConfig(**kwargs)
+    return model_config
+
+
+class InfoGainLLaDAModelLM(PreTrainedModel):
+    """
+    Extremely barebones HF model wrapper.
+    """
+
+    config_class = InfoGainLLaDAConfig
+    base_model_prefix = "model"
+    _no_split_modules = [
+        "InfoGainLLaDABlock",
+        "InfoGainLLaDASequentialBlock",
+        "InfoGainLLaDALlamaBlock",
+    ]
+
+    def __init__(
+        self,
+        config: InfoGainLLaDAConfig,
+        model: Optional[InfoGainLLaDAModel] = None,
+        init_params: bool = False,
+    ):
+        super().__init__(config)
+
+        if not model:
+            model_config = create_model_config_from_pretrained_config(config)
+            # Initialize model (always on CPU to start with so we don't run out of GPU memory).
+            model_config.init_device = "cpu"
+            self.model = InfoGainLLaDAModel(model_config, init_params=init_params)
+        else:
+            self.model = model
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        attention_bias: Optional[torch.Tensor] = None,
+        past_key_values: Optional[List[torch.FloatTensor]] = None,
+        labels: Optional[torch.LongTensor] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+        replace_position: Optional[
+            torch.Tensor
+        ] = None,  # This is a hack mitigation of an issue in transformers `4.39.x`
+    ) -> Union[Tuple, CausalLMOutputWithPast]:
+        if use_cache is None:
+            use_cache = self.config.use_cache
+
+        if output_attentions:
+            raise ValueError("output_attentions is not yet supported in InfoGainLLaDA")
+
+        return_dict = (
+            return_dict if return_dict is not None else self.config.use_return_dict
+        )
+        # import pdb; pdb.set_trace()
+        # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
+
+        outputs = self.model.forward(
+            input_ids=input_ids,
+            input_embeddings=inputs_embeds,
+            attention_mask=attention_mask,
+            attention_bias=attention_bias,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            output_hidden_states=output_hidden_states,
+            replace_position=replace_position,
+        )
+        # import pdb; pdb.set_trace()
+        logits = outputs.logits
+        hidden_states = outputs.hidden_states
+
+        loss = None
+        if labels is not None:
+            import warnings
+
+            warnings.warn(
+                "Note that for InfoGainLLaDA, you cannot calculate the loss here.",
+                UserWarning,
+            )
+        if not return_dict:
+            output = (logits,) + outputs[1:]
+            return (loss,) + output if loss is not None else output
+
+        return CausalLMOutputWithPast(
+            logits=logits,
+            past_key_values=outputs.attn_key_values,
+            hidden_states=hidden_states,
+        )
+
+    def can_generate(self) -> bool:
+        return True
+
+    def prepare_inputs_for_generation(
+        self,
+        input_ids: torch.LongTensor,
+        past_key_values: Optional[List[Tuple]] = None,
+        **kwargs,
+    ):
+        if past_key_values:
+            # This is because we want the model to only process the last generated token.
+            input_ids = input_ids[:, -1:]
+        model_inputs = {"input_ids": input_ids, "past_key_values": past_key_values}
+
+        model_inputs.update(kwargs)
+        model_inputs["use_cache"] = kwargs.pop("use_cache", self.config.use_cache)
+        return model_inputs
+
+    def get_input_embeddings(self) -> torch.nn.Module:
+        return self.model.transformer.wte
+
+    def set_input_embeddings(self, value: torch.nn.Module):
+        self.model.transformer.wte = value
+
+    def get_output_embeddings(self):
+        if self.config.weight_tying:
+            return self.model.transformer.wte
+        else:
+            return self.model.transformer.ff_out
+
+    def set_output_embeddings(self, value: torch.nn.Module):
+        if self.config.weight_tying:
+            self.model.transformer.wte = value
+        else:
+            self.model.transformer.ff_out = value
+
+    def tie_weights(self):
+        if self.config.weight_tying:
+            self.model.transformer.ff_out = self.model.transformer.wte
+
+
+# Register the model so that it is available for transformer pipelines, auto-loading, etc.
+AutoModel.register(InfoGainLLaDAConfig, InfoGainLLaDAModelLM)

--- a/dllm/pipelines/infogain/llada/models/modeling_llada.py
+++ b/dllm/pipelines/infogain/llada/models/modeling_llada.py
@@ -1890,6 +1890,7 @@ class InfoGainLLaDAModelLM(PreTrainedModel):
         config: InfoGainLLaDAConfig,
         model: Optional[InfoGainLLaDAModel] = None,
         init_params: bool = False,
+        **kwargs,
     ):
         super().__init__(config)
 

--- a/dllm/pipelines/infogain/llada/sampler.py
+++ b/dllm/pipelines/infogain/llada/sampler.py
@@ -76,7 +76,22 @@ class InfoGainLLaDASampler(FastdLLMLLaDASampler):
         )
         variant = kwargs.get("variant", config.variant)
 
-        assert block_size >= 1 and steps >= 1
+        steps = int(steps)
+        if steps < 1:
+            raise ValueError(f"steps must be >= 1, got {steps}")
+        candidate_number = int(candidate_number)
+        position_temperature = float(position_temperature)
+        if candidate_number < 1:
+            raise ValueError(
+                f"candidate_number must be >= 1, got {candidate_number}"
+            )
+        if position_temperature < 0:
+            raise ValueError(
+                "position_temperature must be non-negative, "
+                f"got {position_temperature}"
+            )
+        ig.validate_info_gain_variant(variant)
+
         mask_id = self.tokenizer.mask_token_id
         bos_id = self.tokenizer.bos_token_id
         eos_id = self.tokenizer.eos_token_id
@@ -119,20 +134,20 @@ class InfoGainLLaDASampler(FastdLLMLLaDASampler):
             prompt_lens = [p.shape[0] for p in inputs_list]
             max_prompt_len = max(prompt_lens)
 
-        if max_new_tokens is not None:
-            if max_length is None:
-                max_length = max_prompt_len + max_new_tokens
-            else:
-                max_new_tokens = max_length - max_prompt_len
-        else:
-            if max_length is None:
-                raise ValueError("Either max_new_tokens or max_length must be set.")
-            max_new_tokens = max_length - max_prompt_len
+        max_new_tokens, max_length = ig.resolve_generation_lengths(
+            max_new_tokens=max_new_tokens,
+            max_length=max_length,
+            max_prompt_len=max_prompt_len,
+        )
+        block_size = max_new_tokens if block_size is None else int(block_size)
+        if block_size < 1:
+            raise ValueError(f"block_size must be >= 1, got {block_size}")
 
         if B != 1:
             raise ValueError(
                 "Info-Gain LLaDA decoding (use_cache=None) currently supports batch size 1. "
-                "Use Fast-dLLM path by setting use_cache to 'prefix' or 'dual' for batched eval."
+                "Set eval batch_size=1, or use the Fast-dLLM path with use_cache='prefix' "
+                "or 'dual' when batching equal-length prompts."
             )
 
         T = int(max_length)

--- a/dllm/pipelines/infogain/llada/sampler.py
+++ b/dllm/pipelines/infogain/llada/sampler.py
@@ -31,6 +31,9 @@ class InfoGainLLaDASamplerConfig(FastdLLMLLaDASamplerConfig):
     candidate_number: int = 8
     position_temperature: float = 0.2
     variant: str = "info_gain"  # "info_gain" | "lookum"
+    info_gain_cost_reduction: str = "sum"  # "sum" | "mean" ("entropy*")
+    info_gain_cost_weight: float = 1.0
+    info_gain_future_weight: float = 1.0
 
 
 class InfoGainLLaDASampler(FastdLLMLLaDASampler):
@@ -75,6 +78,15 @@ class InfoGainLLaDASampler(FastdLLMLLaDASampler):
             "position_temperature", config.position_temperature
         )
         variant = kwargs.get("variant", config.variant)
+        info_gain_cost_reduction = kwargs.get(
+            "info_gain_cost_reduction", config.info_gain_cost_reduction
+        )
+        info_gain_cost_weight = float(
+            kwargs.get("info_gain_cost_weight", config.info_gain_cost_weight)
+        )
+        info_gain_future_weight = float(
+            kwargs.get("info_gain_future_weight", config.info_gain_future_weight)
+        )
 
         steps = int(steps)
         if steps < 1:
@@ -91,6 +103,9 @@ class InfoGainLLaDASampler(FastdLLMLLaDASampler):
                 f"got {position_temperature}"
             )
         ig.validate_info_gain_variant(variant)
+        info_gain_cost_reduction = ig.normalize_cost_reduction(
+            info_gain_cost_reduction
+        )
 
         mask_id = self.tokenizer.mask_token_id
         bos_id = self.tokenizer.bos_token_id
@@ -257,7 +272,15 @@ class InfoGainLLaDASampler(FastdLLMLLaDASampler):
                         )
 
                     _, _, J = ig.score_candidates(
-                        lx, next_logits, x_batch, actions, mask_id, variant
+                        lx,
+                        next_logits,
+                        x_batch,
+                        actions,
+                        mask_id,
+                        variant,
+                        cost_reduction=info_gain_cost_reduction,
+                        cost_weight=info_gain_cost_weight,
+                        future_weight=info_gain_future_weight,
                     )
                     best = int(J.argmax().item())
                     x_row = x[row].clone()

--- a/dllm/pipelines/infogain/llada/sampler.py
+++ b/dllm/pipelines/infogain/llada/sampler.py
@@ -231,7 +231,7 @@ class InfoGainLLaDASampler(FastdLLMLLaDASampler):
                         continue
                     best_pos = valid[conf_base[0, valid].argmax()].unsqueeze(0)
                     x_row = x[row].clone()
-                    x_row[best_pos] = x0s[0][0, best_pos]
+                    x_row[best_pos] = x0s[0, best_pos]
                     x[row] = x_row
                     continue
 

--- a/dllm/pipelines/infogain/llada/sampler.py
+++ b/dllm/pipelines/infogain/llada/sampler.py
@@ -143,13 +143,6 @@ class InfoGainLLaDASampler(FastdLLMLLaDASampler):
         if block_size < 1:
             raise ValueError(f"block_size must be >= 1, got {block_size}")
 
-        if B != 1:
-            raise ValueError(
-                "Info-Gain LLaDA decoding (use_cache=None) currently supports batch size 1. "
-                "Set eval batch_size=1, or use the Fast-dLLM path with use_cache='prefix' "
-                "or 'dual' when batching equal-length prompts."
-            )
-
         T = int(max_length)
         x = torch.full((B, T), eos_id, dtype=torch.long, device=self.model.device)
         attention_mask = torch.zeros((B, T), dtype=torch.long, device=self.model.device)
@@ -176,16 +169,11 @@ class InfoGainLLaDASampler(FastdLLMLLaDASampler):
 
         for b in range(num_blocks):
             widths: list[tuple[int, int, int]] = []
-            block_mask_index = torch.zeros(
-                (B, block_size), dtype=torch.bool, device=x.device
-            )
             for j in range(B):
                 start_j = prompt_lens[j] + b * block_size
                 end_j = min(start_j + block_size, prompt_lens[j] + max_new_tokens, T)
                 width_j = max(0, end_j - start_j)
                 widths.append((start_j, end_j, width_j))
-                if width_j > 0:
-                    block_mask_index[j, :width_j] = x[j, start_j:end_j] == mask_id
 
             for _step in range(steps_per_block):
                 mask_allowed = torch.zeros_like(x, dtype=torch.bool)
@@ -203,75 +191,83 @@ class InfoGainLLaDASampler(FastdLLMLLaDASampler):
                 if right_shift_logits:
                     logits = torch.cat([logits[:, :1], logits[:, :-1]], dim=1)
 
-                row = 0
-                start_j, end_j, width_j = widths[row]
-                if width_j == 0:
-                    continue
-                bs, be = start_j, end_j
-                lx = logits[row : row + 1]
-                xx = x[row : row + 1]
-                ma = mask_allowed[row : row + 1]
-
-                probs = F.softmax(lx[:, bs:be].float(), dim=-1)
-                max_conf = probs.max(-1).values
-                block_masked = ma[0, bs:be]
-                if (
-                    threshold is not None
-                    and threshold > 0
-                    and block_masked.any()
-                    and (max_conf[0][block_masked] >= threshold).all()
-                ):
-                    xx_new = ig.greedy_unmask_block(
-                        xx, lx, ma, bs, be, temperature, mask_id
-                    )
-                    x[row : row + 1] = xx_new
-                    continue
-
-                k = 1
-                result = ig.generate_candidates(
-                    lx,
-                    xx,
-                    ma,
-                    bs,
-                    be,
-                    k,
-                    candidate_number,
-                    temperature,
-                    position_temperature,
-                )
-                actions, x0s, conf_base, valid, _ = result
-
-                if actions is None:
-                    if valid.shape[0] == 0:
+                changed = False
+                for row in range(B):
+                    start_j, end_j, width_j = widths[row]
+                    if width_j == 0:
                         continue
-                    best_pos = valid[conf_base[0, valid].argmax()].unsqueeze(0)
-                    x_row = x[row].clone()
-                    x_row[best_pos] = x0s[0, best_pos]
-                    x[row] = x_row
-                    continue
+                    bs, be = start_j, end_j
+                    lx = logits[row : row + 1]
+                    xx = x[row : row + 1]
+                    ma = mask_allowed[row : row + 1]
+                    if not ma[:, bs:be].any():
+                        continue
 
-                nc = len(actions)
-                x_batch = xx.expand(nc, -1).clone()
-                for i, (act, x0) in enumerate(zip(actions, x0s)):
-                    x_batch[i, act] = x0[0, act]
+                    probs = F.softmax(lx[:, bs:be].float(), dim=-1)
+                    max_conf = probs.max(-1).values
+                    block_masked = ma[0, bs:be]
+                    if (
+                        threshold is not None
+                        and threshold > 0
+                        and block_masked.any()
+                        and (max_conf[0][block_masked] >= threshold).all()
+                    ):
+                        xx_new = ig.greedy_unmask_block(
+                            xx, lx, ma, bs, be, temperature, mask_id
+                        )
+                        x[row : row + 1] = xx_new
+                        changed = True
+                        continue
 
-                attn = attention_mask[row : row + 1].expand(nc, -1)
-                next_logits = self.model(x_batch, attention_mask=attn).logits
-                _apply_suppressions(next_logits)
-                if right_shift_logits:
-                    next_logits = torch.cat(
-                        [next_logits[:, :1], next_logits[:, :-1]], dim=1
+                    k = 1
+                    result = ig.generate_candidates(
+                        lx,
+                        xx,
+                        ma,
+                        bs,
+                        be,
+                        k,
+                        candidate_number,
+                        temperature,
+                        position_temperature,
                     )
+                    actions, x0s, conf_base, valid, _ = result
 
-                _, _, J = ig.score_candidates(
-                    lx, next_logits, x_batch, actions, mask_id, variant
-                )
-                best = int(J.argmax().item())
-                x_row = x[row].clone()
-                act = actions[best]
-                x_row[act] = x0s[best][0, act]
-                x[row] = x_row
+                    if actions is None:
+                        if valid.shape[0] == 0:
+                            continue
+                        best_pos = valid[conf_base[0, valid].argmax()].unsqueeze(0)
+                        x_row = x[row].clone()
+                        x_row[best_pos] = x0s[0, best_pos]
+                        x[row] = x_row
+                        changed = True
+                        continue
 
+                    nc = len(actions)
+                    x_batch = xx.expand(nc, -1).clone()
+                    for i, (act, x0) in enumerate(zip(actions, x0s)):
+                        x_batch[i, act] = x0[0, act]
+
+                    attn = attention_mask[row : row + 1].expand(nc, -1)
+                    next_logits = self.model(x_batch, attention_mask=attn).logits
+                    _apply_suppressions(next_logits)
+                    if right_shift_logits:
+                        next_logits = torch.cat(
+                            [next_logits[:, :1], next_logits[:, :-1]], dim=1
+                        )
+
+                    _, _, J = ig.score_candidates(
+                        lx, next_logits, x_batch, actions, mask_id, variant
+                    )
+                    best = int(J.argmax().item())
+                    x_row = x[row].clone()
+                    act = actions[best]
+                    x_row[act] = x0s[best][0, act]
+                    x[row] = x_row
+                    changed = True
+
+                if not changed:
+                    break
                 if histories is not None:
                     histories.append(x.clone())
 

--- a/dllm/pipelines/infogain/llada/sampler.py
+++ b/dllm/pipelines/infogain/llada/sampler.py
@@ -1,0 +1,274 @@
+"""
+Info-Gain LLaDA sampler (no KV cache path), with Fast-dLLM KV cache decoding when ``use_cache`` is set.
+
+Reference: https://github.com/yks23/Information-Gain-Sampler
+Fast-dLLM cache path: https://github.com/NVlabs/Fast-dLLM
+
+Run: python -u examples/infogain/llada/sample.py --model_name_or_path "GSAI-ML/LLaDA-8B-Instruct"
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import List, Optional, Union
+
+import torch
+import torch.nn.functional as F
+
+from dllm.core.samplers.base import BaseSamplerOutput
+from dllm.pipelines.fastdllm.llada.sampler import (
+    FastdLLMLLaDASampler,
+    FastdLLMLLaDASamplerConfig,
+)
+from dllm.pipelines.infogain import info_gain_ops as ig
+
+
+@dataclass
+class InfoGainLLaDASamplerConfig(FastdLLMLLaDASamplerConfig):
+    """Info-Gain fields (used when ``use_cache`` is ``None``)."""
+
+    candidate_number: int = 8
+    position_temperature: float = 0.2
+    variant: str = "info_gain"  # "info_gain" | "lookum"
+
+
+class InfoGainLLaDASampler(FastdLLMLLaDASampler):
+    """LLaDA sampler: Info-Gain when ``use_cache=None``; otherwise Fast-dLLM KV-cache decoding."""
+
+    @torch.no_grad()
+    def sample(
+        self,
+        inputs: Union[List[torch.Tensor], List[List[int]], torch.Tensor],
+        config: Optional[InfoGainLLaDASamplerConfig] = None,
+        **kwargs,
+    ) -> BaseSamplerOutput | torch.Tensor:
+        cfg = config or InfoGainLLaDASamplerConfig()
+        use_cache = kwargs.get("use_cache", cfg.use_cache)
+        if use_cache == "none":
+            use_cache = None
+        if use_cache is not None:
+            return super().sample(inputs, config=cfg, **kwargs)
+        return self._sample_info_gain_no_cache(inputs, cfg, **kwargs)
+
+    @torch.no_grad()
+    def _sample_info_gain_no_cache(
+        self,
+        inputs: Union[List[torch.Tensor], List[List[int]], torch.Tensor],
+        config: InfoGainLLaDASamplerConfig,
+        **kwargs,
+    ) -> BaseSamplerOutput | torch.Tensor:
+        steps = kwargs.get("steps", config.steps)
+        max_new_tokens = kwargs.get("max_new_tokens", config.max_new_tokens)
+        max_length = kwargs.get("max_length", config.max_length)
+        block_size = kwargs.get("block_size", config.block_size)
+        temperature = kwargs.get("temperature", config.temperature)
+        return_dict = kwargs.get("return_dict", config.return_dict)
+        right_shift_logits = kwargs.get("right_shift_logits", config.right_shift_logits)
+        suppress_tokens = kwargs.get("suppress_tokens", config.suppress_tokens)
+        begin_suppress_tokens = kwargs.get(
+            "begin_suppress_tokens", config.begin_suppress_tokens
+        )
+        threshold = kwargs.get("threshold", config.threshold)
+        candidate_number = kwargs.get("candidate_number", config.candidate_number)
+        position_temperature = kwargs.get(
+            "position_temperature", config.position_temperature
+        )
+        variant = kwargs.get("variant", config.variant)
+
+        assert block_size >= 1 and steps >= 1
+        mask_id = self.tokenizer.mask_token_id
+        bos_id = self.tokenizer.bos_token_id
+        eos_id = self.tokenizer.eos_token_id
+
+        if isinstance(inputs, torch.Tensor):
+            if inputs.dim() == 1:
+                inputs = inputs.unsqueeze(0)
+            inputs_list = [
+                row.to(device=self.model.device, dtype=torch.long) for row in inputs
+            ]
+        else:
+            if len(inputs) == 0:
+                raise ValueError("inputs is empty")
+            if isinstance(inputs[0], list):
+                inputs_list = [
+                    torch.as_tensor(p, dtype=torch.long, device=self.model.device)
+                    for p in inputs  # type: ignore[arg-type]
+                ]
+            else:
+                inputs_list = [
+                    p.to(device=self.model.device, dtype=torch.long) for p in inputs  # type: ignore[arg-type]
+                ]
+
+        prompt_lens = [p.shape[0] for p in inputs_list]
+        B = len(inputs_list)
+        max_prompt_len = max(prompt_lens)
+
+        if right_shift_logits:
+            fixed = []
+            for p in inputs_list:
+                if p.numel() == 0:
+                    fixed.append(
+                        torch.tensor(
+                            [bos_id], device=self.model.device, dtype=torch.long
+                        )
+                    )
+                else:
+                    fixed.append(p)
+            inputs_list = fixed
+            prompt_lens = [p.shape[0] for p in inputs_list]
+            max_prompt_len = max(prompt_lens)
+
+        if max_new_tokens is not None:
+            if max_length is None:
+                max_length = max_prompt_len + max_new_tokens
+            else:
+                max_new_tokens = max_length - max_prompt_len
+        else:
+            if max_length is None:
+                raise ValueError("Either max_new_tokens or max_length must be set.")
+            max_new_tokens = max_length - max_prompt_len
+
+        if B != 1:
+            raise ValueError(
+                "Info-Gain LLaDA decoding (use_cache=None) currently supports batch size 1. "
+                "Use Fast-dLLM path by setting use_cache to 'prefix' or 'dual' for batched eval."
+            )
+
+        T = int(max_length)
+        x = torch.full((B, T), eos_id, dtype=torch.long, device=self.model.device)
+        attention_mask = torch.zeros((B, T), dtype=torch.long, device=self.model.device)
+
+        for i, p in enumerate(inputs_list):
+            pl = p.shape[0]
+            x[i, :pl] = p
+            gen_end = min(pl + max_new_tokens, T)
+            x[i, pl:gen_end] = mask_id
+            attention_mask[i, :gen_end] = 1
+
+        histories = [x.clone()] if return_dict else None
+
+        num_blocks = max(1, math.ceil(max_new_tokens / block_size))
+        steps_per_block = max(1, math.ceil(steps / num_blocks))
+
+        def _apply_suppressions(logits_: torch.Tensor):
+            if suppress_tokens:
+                for tid in suppress_tokens:
+                    logits_[:, :, tid] = -torch.inf
+            if begin_suppress_tokens:
+                for tid in begin_suppress_tokens:
+                    logits_[:, :, tid] = -torch.inf
+
+        for b in range(num_blocks):
+            widths: list[tuple[int, int, int]] = []
+            block_mask_index = torch.zeros(
+                (B, block_size), dtype=torch.bool, device=x.device
+            )
+            for j in range(B):
+                start_j = prompt_lens[j] + b * block_size
+                end_j = min(start_j + block_size, prompt_lens[j] + max_new_tokens, T)
+                width_j = max(0, end_j - start_j)
+                widths.append((start_j, end_j, width_j))
+                if width_j > 0:
+                    block_mask_index[j, :width_j] = x[j, start_j:end_j] == mask_id
+
+            for _step in range(steps_per_block):
+                mask_allowed = torch.zeros_like(x, dtype=torch.bool)
+                for j in range(B):
+                    start_j, end_j, width_j = widths[j]
+                    if width_j > 0:
+                        mask_allowed[j, start_j:end_j] = x[j, start_j:end_j] == mask_id
+
+                if mask_allowed.sum() == 0:
+                    break
+
+                out = self.model(x, attention_mask=attention_mask)
+                logits = out.logits
+                _apply_suppressions(logits)
+                if right_shift_logits:
+                    logits = torch.cat([logits[:, :1], logits[:, :-1]], dim=1)
+
+                row = 0
+                start_j, end_j, width_j = widths[row]
+                if width_j == 0:
+                    continue
+                bs, be = start_j, end_j
+                lx = logits[row : row + 1]
+                xx = x[row : row + 1]
+                ma = mask_allowed[row : row + 1]
+
+                probs = F.softmax(lx[:, bs:be].float(), dim=-1)
+                max_conf = probs.max(-1).values
+                block_masked = ma[0, bs:be]
+                if (
+                    threshold is not None
+                    and threshold > 0
+                    and block_masked.any()
+                    and (max_conf[0][block_masked] >= threshold).all()
+                ):
+                    xx_new = ig.greedy_unmask_block(
+                        xx, lx, ma, bs, be, temperature, mask_id
+                    )
+                    x[row : row + 1] = xx_new
+                    continue
+
+                k = 1
+                result = ig.generate_candidates(
+                    lx,
+                    xx,
+                    ma,
+                    bs,
+                    be,
+                    k,
+                    candidate_number,
+                    temperature,
+                    position_temperature,
+                )
+                actions, x0s, conf_base, valid, _ = result
+
+                if actions is None:
+                    if valid.shape[0] == 0:
+                        continue
+                    best_pos = valid[conf_base[0, valid].argmax()].unsqueeze(0)
+                    x_row = x[row].clone()
+                    x_row[best_pos] = x0s[0][0, best_pos]
+                    x[row] = x_row
+                    continue
+
+                nc = len(actions)
+                x_batch = xx.expand(nc, -1).clone()
+                for i, (act, x0) in enumerate(zip(actions, x0s)):
+                    x_batch[i, act] = x0[0, act]
+
+                attn = attention_mask[row : row + 1].expand(nc, -1)
+                next_logits = self.model(x_batch, attention_mask=attn).logits
+                _apply_suppressions(next_logits)
+                if right_shift_logits:
+                    next_logits = torch.cat(
+                        [next_logits[:, :1], next_logits[:, :-1]], dim=1
+                    )
+
+                _, _, J = ig.score_candidates(
+                    lx, next_logits, x_batch, actions, mask_id, variant
+                )
+                best = int(J.argmax().item())
+                x_row = x[row].clone()
+                act = actions[best]
+                x_row[act] = x0s[best][0, act]
+                x[row] = x_row
+
+                if histories is not None:
+                    histories.append(x.clone())
+
+        if not return_dict:
+            return x
+        return BaseSamplerOutput(sequences=x, histories=histories)
+
+    @torch.no_grad()
+    def infill(
+        self,
+        inputs: Union[List[torch.Tensor], List[List[int]]],
+        config: InfoGainLLaDASamplerConfig | None = None,
+        **kwargs,
+    ) -> BaseSamplerOutput:
+        raise NotImplementedError

--- a/dllm/utils/models.py
+++ b/dllm/utils/models.py
@@ -95,18 +95,35 @@ def get_tokenizer(
     # Lazy imports to avoid circular dependencies
     from transformers import (
         BertPreTrainedModel,
-        ModernBertPreTrainedModel,
         RobertaPreTrainedModel,
     )
+    try:
+        from transformers import ModernBertPreTrainedModel
+    except ImportError:
+        ModernBertPreTrainedModel = None
 
-    from dllm.pipelines.a2d import (
-        A2DLlamaLMHeadModel,
-        A2DQwen2LMHeadModel,
-        A2DQwen3LMHeadModel,
-    )
-    from dllm.pipelines.dream.models.modeling_dream import DreamModel
-    from dllm.pipelines.llada2.models import modeling_llada2_moe as llada2_moe_mod
-    from dllm.pipelines.llada21.models import modeling_llada21_moe as llada21_moe_mod
+    try:
+        from dllm.pipelines.a2d import (
+            A2DLlamaLMHeadModel,
+            A2DQwen2LMHeadModel,
+            A2DQwen3LMHeadModel,
+        )
+    except ImportError:
+        A2DLlamaLMHeadModel = None
+        A2DQwen2LMHeadModel = None
+        A2DQwen3LMHeadModel = None
+    try:
+        from dllm.pipelines.dream.models.modeling_dream import DreamModel
+    except ImportError:
+        DreamModel = None
+    try:
+        from dllm.pipelines.llada2.models import modeling_llada2_moe as llada2_moe_mod
+    except ImportError:
+        llada2_moe_mod = None
+    try:
+        from dllm.pipelines.llada21.models import modeling_llada21_moe as llada21_moe_mod
+    except ImportError:
+        llada21_moe_mod = None
     from dllm.pipelines.llada.models.modeling_llada import LLaDAModelLM
     from dllm.pipelines.llada.models.modeling_lladamoe import LLaDAMoEModelLM
 
@@ -134,6 +151,15 @@ def get_tokenizer(
     model_cfg = transformers.AutoConfig.from_pretrained(model_name_or_path)
     model_cls = transformers.AutoModel._model_mapping[type(model_cfg)]
 
+    bert_model_classes = [BertPreTrainedModel, RobertaPreTrainedModel]
+    if ModernBertPreTrainedModel is not None:
+        bert_model_classes.append(ModernBertPreTrainedModel)
+    llada_moe_model_classes = [LLaDAMoEModelLM]
+    if llada2_moe_mod is not None:
+        llada_moe_model_classes.append(llada2_moe_mod.LLaDA2MoeModelLM)
+    if llada21_moe_mod is not None:
+        llada_moe_model_classes.append(llada21_moe_mod.LLaDA2MoeModelLM)
+
     # ---------------- Model-specific customization ----------------
     if issubclass(model_cls, LLaDAModelLM):
         tokenizer.add_special_tokens({"mask_token": "<|mdm_mask|>"})
@@ -154,24 +180,14 @@ def get_tokenizer(
 
 {% endif %}
 """
-    elif issubclass(
-        model_cls,
-        (
-            LLaDAMoEModelLM,
-            llada2_moe_mod.LLaDA2MoeModelLM,
-            llada21_moe_mod.LLaDA2MoeModelLM,
-        ),
-    ):
+    elif issubclass(model_cls, tuple(llada_moe_model_classes)):
         tokenizer.add_special_tokens({"mask_token": "<|mask|>"})
         tokenizer.eot_token = "<|role_end|>"
         tokenizer.eot_token_id = tokenizer.convert_tokens_to_ids(tokenizer.eot_token)
-    elif issubclass(model_cls, DreamModel):
+    elif DreamModel is not None and issubclass(model_cls, DreamModel):
         tokenizer.eot_token = "<|im_end|>"
         tokenizer.eot_token_id = tokenizer.convert_tokens_to_ids(tokenizer.eot_token)
-    elif issubclass(
-        model_cls,
-        (BertPreTrainedModel, RobertaPreTrainedModel, ModernBertPreTrainedModel),
-    ):
+    elif issubclass(model_cls, tuple(bert_model_classes)):
         tokenizer.eot_token = "[/Answer]"
         tokenizer.chat_template = """\
 {% if messages[0]['role'] == 'system' %}
@@ -200,11 +216,11 @@ def get_tokenizer(
 [Answer]
 {% endif %}
 """
-    elif issubclass(model_cls, A2DLlamaLMHeadModel):
+    elif A2DLlamaLMHeadModel is not None and issubclass(model_cls, A2DLlamaLMHeadModel):
         tokenizer.add_special_tokens({"mask_token": "<|mask|>"})
         tokenizer.eot_token = "<|eot_id|>"
         tokenizer.eot_token_id = tokenizer.convert_tokens_to_ids(tokenizer.eot_token)
-    elif issubclass(model_cls, (A2DQwen2LMHeadModel, A2DQwen3LMHeadModel)):
+    elif any(cls is not None and issubclass(model_cls, cls) for cls in (A2DQwen2LMHeadModel, A2DQwen3LMHeadModel)):
         tokenizer.add_special_tokens({"mask_token": "<|mask|>"})
         tokenizer.eot_token = "<|im_end|>"
         tokenizer.eot_token_id = tokenizer.convert_tokens_to_ids(tokenizer.eot_token)

--- a/examples/dream/README.md
+++ b/examples/dream/README.md
@@ -159,6 +159,8 @@ bash examples/dream/eval.sh --model_name_or_path "Dream-org/Dream-v0-Base-7B" --
 
 For **Fast-dLLM** sampling and evaluation with Dream, see the [Fast-dLLM README](../fastdllm/README.md).
 
+For **Info-Gain** sampling and evaluation with Dream, see the [Info-Gain README](../infogain/README.md).
+
 ### Evaluation results
 
 > Results (Reproduced) are evaluated using our framework, while results (Official) come from the original [paper](https://arxiv.org/abs/2508.15487). All evaluation settings follow the configurations in the [Dream](https://github.com/DreamLM/Dream) repository, with minor adjustments.

--- a/examples/infogain/README.md
+++ b/examples/infogain/README.md
@@ -56,6 +56,23 @@ python examples/infogain/llada/sample.py \
     --use_cache none --threshold 0.8 --candidate_number 8 --position_temperature 0.2 --variant info_gain
 ```
 
+The Info-Gain objective is weighted as
+`J = -cost_weight * C - future_weight * H_next`. By default,
+`cost_weight=1`, `future_weight=1`, and `C` is the sum of entropies over
+the decoded action. Set `info_gain_cost_reduction=mean` to use
+**entropy\***, i.e. the average entropy of the token(s) decoded by the
+current action. The mean reduction can be stronger than the default sum
+reduction in some settings, especially when comparing candidate actions with
+different decoded-token counts or under very small decoding-step budgets:
+
+```shell
+python examples/infogain/llada/sample.py \
+    --model_name_or_path "GSAI-ML/LLaDA-8B-Instruct" \
+    --use_cache none --threshold 0.8 --candidate_number 8 --position_temperature 0.2 \
+    --variant info_gain --info_gain_cost_reduction mean \
+    --info_gain_cost_weight 1.5 --info_gain_future_weight 1.0
+```
+
 Sampling with the Info-Gain Dream sampler (`use_cache none`, `alg=info_gain`; other `alg` values match Fast-dLLM Dream):
 
 ```shell
@@ -64,6 +81,10 @@ python examples/infogain/dream/sample.py \
     --model_name_or_path "Dream-org/Dream-v0-Instruct-7B" \
     --use_cache none --alg info_gain --threshold 0.8 --candidate_number 8
 ```
+
+Dream accepts the same Info-Gain weighting controls through
+`info_gain_cost_reduction`, `info_gain_cost_weight`, and
+`info_gain_future_weight`.
 
 ## Correctness smoke tests
 
@@ -114,7 +135,7 @@ python scripts/tests/test_infogain_real_inference.py \
 For example, to evaluate [LLaDA-8B-Instruct](https://huggingface.co/GSAI-ML/LLaDA-8B-Instruct) or [Dream-v0-Instruct-7B](https://huggingface.co/Dream-org/Dream-v0-Instruct-7B) on [GSM8K](https://huggingface.co/datasets/openai/gsm8k) with 4 GPUs, run:
 
 ```shell
-# Pass Info-Gain options via model_args (use_cache=none, threshold, candidate_number, position_temperature, variant, etc.).
+# Pass Info-Gain options via model_args (use_cache=none, threshold, candidate_number, position_temperature, variant, weighting, etc.).
 accelerate launch --num_processes 4 \
     dllm/pipelines/infogain/llada/eval.py \
     --tasks "gsm8k" \
@@ -143,6 +164,7 @@ Optional flags for `eval.sh`: `--max_new_tokens`, `--threshold`, `--candidate_nu
 
 ## Notes
 
-- **Batch size**: Info-Gain decoding for both LLaDA (`use_cache=none`) and Dream (`alg=info_gain` with `use_cache=none`) currently requires **batch size 1**. Keep per-process batch at 1 under multi-GPU `lm-eval` / `accelerate` runs.
+- **Batch size**: Info-Gain no-cache decoding supports batched inputs for both LLaDA (`use_cache=none`) and Dream (`alg=info_gain` with `use_cache=none`). The smoke tests also cover the Fast-dLLM-compatible prefix / dual cache paths.
+- **Objective weighting**: `info_gain_cost_reduction=sum` is the default and matches the original immediate cost. `info_gain_cost_reduction=mean` enables **entropy\***, the average entropy of the decoded action tokens. `info_gain_cost_weight` and `info_gain_future_weight` control the immediate-cost and future-uncertainty terms.
 - **LLaDA**: `use_cache=prefix` or `dual` uses the Fast-dLLM-style KV and parallel decode path inside the Info-Gain pipeline module (not the inner Info-Gain objective), useful for comparing against Fast-dLLM.
 - **Dream**: `alg=info_gain` is only active when **`use_cache=none`**; other settings follow the Dream sampler’s Fast-dLLM-compatible branches.

--- a/examples/infogain/README.md
+++ b/examples/infogain/README.md
@@ -1,0 +1,83 @@
+# Info-Gain dLLM
+
+> 论文: [Improving Sampling for Masked Diffusion Models via Information Gain](https://arxiv.org/abs/2602.18176)（**ICML 2026** 录用）· 官方实现参考: [Information-Gain-Sampler](https://github.com/yks23/Information-Gain-Sampler)
+
+在 **LLaDA** 与 **Dream** 上提供与 `examples/fastdllm` 对称的推理与评测入口；解码算法来自 Information-Gain-Sampler 的 **候选–打分–提交** 循环，并与本仓库的 `accelerate` / `lm-eval` 流程对齐。
+
+## 目录结构
+
+```
+dllm/pipelines/infogain
+├── __init__.py
+├── info_gain_ops.py          # 与上游一致的熵 / 候选 / 打分工具
+├── dream/
+│   ├── __init__.py
+│   ├── eval.py               # lm-eval: --model infogain_dream
+│   ├── sampler.py
+│   └── models/
+│       ├── configuration_dream.py
+│       ├── modeling_dream.py
+│       └── __init__.py
+└── llada/
+    ├── __init__.py
+    ├── eval.py               # lm-eval: --model infogain_llada
+    ├── sampler.py
+    └── models/
+        ├── configuration_llada.py
+        ├── modeling_llada.py
+        └── __init__.py
+
+examples/infogain
+├── README.md
+├── llada/sample.py
+├── llada/eval.sh
+├── dream/sample.py
+└── dream/eval.sh
+```
+
+## 推理
+
+**LLaDA**（`use_cache=None` 走 Info-Gain；`prefix` / `dual` 走 Fast-dLLM 同款 KV 路径）：
+
+```shell
+python examples/infogain/llada/sample.py \
+  --model_name_or_path "GSAI-ML/LLaDA-8B-Instruct" \
+  --use_cache none --threshold 0.8 --candidate_number 8 --position_temperature 0.2 --variant info_gain
+```
+
+**Dream**（`use_cache=None` 且 `alg=info_gain`；其它 `alg` 与 Fast-dLLM Dream 行为一致）：
+
+```shell
+python examples/infogain/dream/sample.py \
+  --model_name_or_path "Dream-org/Dream-v0-Instruct-7B" \
+  --use_cache none --alg info_gain --threshold 0.8 --candidate_number 8
+```
+
+## 评测
+
+评测前请阅读仓库根目录 [README.md](/README.md) 中的评测环境说明。
+
+```shell
+accelerate launch --num_processes 4 \
+  dllm/pipelines/infogain/llada/eval.py \
+  --tasks gsm8k --num_fewshot 5 --model infogain_llada --apply_chat_template \
+  --model_args "pretrained=GSAI-ML/LLaDA-8B-Instruct,use_cache=none,threshold=0.8,candidate_number=8,max_new_tokens=256,steps=256,block_size=32,suppress_tokens=[],begin_suppress_tokens=[]"
+
+accelerate launch --num_processes 4 \
+  dllm/pipelines/infogain/dream/eval.py \
+  --tasks gsm8k --num_fewshot 5 --model infogain_dream --apply_chat_template \
+  --model_args "pretrained=Dream-org/Dream-v0-Instruct-7B,use_cache=none,alg=info_gain,threshold=0.8,candidate_number=8,max_new_tokens=256,steps=256,block_size=32,dtype=bfloat16,add_bos_token=True"
+```
+
+或使用脚本：
+
+```shell
+bash examples/infogain/llada/eval.sh --model_name_or_path "GSAI-ML/LLaDA-8B-Instruct" --instruct True --num_gpu 1
+bash examples/infogain/dream/eval.sh --model_name_or_path "Dream-org/Dream-v0-Base-7B" --instruct False --num_gpu 1
+```
+
+## 说明
+
+- LLaDA 在 **`use_cache=None`** 时采用 Info-Gain 单步解码；**当前实现要求 batch size 为 1**。多卡评测时请保持每进程 batch 为 1（与常见 `lm-eval` 设置一致）。
+- 设置 `use_cache` 为 `prefix` 或 `dual` 时，LLaDA 采样器继承 Fast-dLLM 的 KV 与并行解码逻辑，便于与 Fast-dLLM 基线对比。
+- Dream 的 **`alg=info_gain`** 仅在 **`use_cache=None`** 时生效，且 **batch size 须为 1**。

--- a/examples/infogain/README.md
+++ b/examples/infogain/README.md
@@ -1,83 +1,148 @@
 # Info-Gain dLLM
 
-> 论文: [Improving Sampling for Masked Diffusion Models via Information Gain](https://arxiv.org/abs/2602.18176)（**ICML 2026** 录用）· 官方实现参考: [Information-Gain-Sampler](https://github.com/yks23/Information-Gain-Sampler)
+> Paper: [Improving Sampling for Masked Diffusion Models via Information Gain](https://arxiv.org/abs/2602.18176) (**ICML 2026**) | Reference implementation: [Information-Gain-Sampler](https://github.com/yks23/Information-Gain-Sampler)
 
-在 **LLaDA** 与 **Dream** 上提供与 `examples/fastdllm` 对称的推理与评测入口；解码算法来自 Information-Gain-Sampler 的 **候选–打分–提交** 循环，并与本仓库的 `accelerate` / `lm-eval` 流程对齐。
+Resources and examples for inferencing and evaluating **LLaDA** and **Dream** with the **Information Gain** sampler. Layout mirrors [`examples/fastdllm`](/examples/fastdllm): the decode loop follows the upstream **propose–score–commit** pattern, wired to this repo’s **`accelerate` / `lm-eval`** harness.
 
-## 目录结构
+## Table of Contents
+- [Files](#files)
+- [Inference](#inference)
+- [Evaluation](#evaluation)
+- [Notes](#notes)
+
+## Files
 
 ```
+# Pipeline modules for Info-Gain
 dllm/pipelines/infogain
 ├── __init__.py
-├── info_gain_ops.py          # 与上游一致的熵 / 候选 / 打分工具
+├── info_gain_ops.py                # Entropy / candidates / scoring (aligned with upstream)
 ├── dream/
 │   ├── __init__.py
-│   ├── eval.py               # lm-eval: --model infogain_dream
-│   ├── sampler.py
-│   └── models/
-│       ├── configuration_dream.py
-│       ├── modeling_dream.py
-│       └── __init__.py
+│   ├── models/
+│   │   ├── configuration_dream.py  # Info-Gain Dream model configuration
+│   │   └── modeling_dream.py       # Info-Gain Dream model architecture
+│   ├── sampler.py                  # Info-Gain Dream inference module
+│   └── eval.py                     # lm-eval harness: --model infogain_dream
 └── llada/
     ├── __init__.py
-    ├── eval.py               # lm-eval: --model infogain_llada
-    ├── sampler.py
-    └── models/
-        ├── configuration_llada.py
-        ├── modeling_llada.py
-        └── __init__.py
+    ├── models/
+    │   ├── configuration_llada.py  # Info-Gain LLaDA model configuration
+    │   └── modeling_llada.py       # Info-Gain LLaDA model architecture
+    ├── sampler.py                  # Info-Gain LLaDA inference module
+    └── eval.py                     # lm-eval harness: --model infogain_llada
 
+# Example entry points for inference and evaluation
 examples/infogain
-├── README.md
-├── llada/sample.py
-├── llada/eval.sh
-├── dream/sample.py
-└── dream/eval.sh
+├── README.md                       # Documentation (you are here)
+├── dream/
+│   ├── sample.py                   # Info-Gain Dream inference example
+│   └── eval.sh                     # Info-Gain Dream evaluation script (baseline + Info-Gain)
+└── llada/
+    ├── sample.py                   # Info-Gain LLaDA inference example
+    └── eval.sh                     # Info-Gain LLaDA evaluation script (baseline + Info-Gain + prefix cache)
 ```
 
-## 推理
+## Inference
 
-**LLaDA**（`use_cache=None` 走 Info-Gain；`prefix` / `dual` 走 Fast-dLLM 同款 KV 路径）：
+> With **`use_cache=none`**, LLaDA uses Info-Gain per-step decoding. With **`use_cache=prefix`** or **`dual`**, the sampler reuses the same KV / parallel path as Fast-dLLM for apples-to-apples baselines.
+
+Sampling with the Info-Gain LLaDA sampler (`use_cache none`, confidence threshold, candidate count, position temperature, `variant=info_gain`):
 
 ```shell
+# --use_cache none enables Info-Gain; --threshold / --candidate_number / --position_temperature tune the sampler
 python examples/infogain/llada/sample.py \
-  --model_name_or_path "GSAI-ML/LLaDA-8B-Instruct" \
-  --use_cache none --threshold 0.8 --candidate_number 8 --position_temperature 0.2 --variant info_gain
+    --model_name_or_path "GSAI-ML/LLaDA-8B-Instruct" \
+    --use_cache none --threshold 0.8 --candidate_number 8 --position_temperature 0.2 --variant info_gain
 ```
 
-**Dream**（`use_cache=None` 且 `alg=info_gain`；其它 `alg` 与 Fast-dLLM Dream 行为一致）：
+Sampling with the Info-Gain Dream sampler (`use_cache none`, `alg=info_gain`; other `alg` values match Fast-dLLM Dream):
 
 ```shell
+# --use_cache none and --alg info_gain enable Information-Gain decoding; --threshold / --candidate_number match the paper-style loop
 python examples/infogain/dream/sample.py \
-  --model_name_or_path "Dream-org/Dream-v0-Instruct-7B" \
-  --use_cache none --alg info_gain --threshold 0.8 --candidate_number 8
+    --model_name_or_path "Dream-org/Dream-v0-Instruct-7B" \
+    --use_cache none --alg info_gain --threshold 0.8 --candidate_number 8
 ```
 
-## 评测
+## Correctness smoke tests
 
-评测前请阅读仓库根目录 [README.md](/README.md) 中的评测环境说明。
+The repository includes GPU smoke tests for sampler correctness:
 
 ```shell
-accelerate launch --num_processes 4 \
-  dllm/pipelines/infogain/llada/eval.py \
-  --tasks gsm8k --num_fewshot 5 --model infogain_llada --apply_chat_template \
-  --model_args "pretrained=GSAI-ML/LLaDA-8B-Instruct,use_cache=none,threshold=0.8,candidate_number=8,max_new_tokens=256,steps=256,block_size=32,suppress_tokens=[],begin_suppress_tokens=[]"
+# Toy-model GPU test: verifies Info-Gain no-cache decoding and candidate scoring.
+python scripts/tests/test_infogain_gpu_smoke.py
 
-accelerate launch --num_processes 4 \
-  dllm/pipelines/infogain/dream/eval.py \
-  --tasks gsm8k --num_fewshot 5 --model infogain_dream --apply_chat_template \
-  --model_args "pretrained=Dream-org/Dream-v0-Instruct-7B,use_cache=none,alg=info_gain,threshold=0.8,candidate_number=8,max_new_tokens=256,steps=256,block_size=32,dtype=bfloat16,add_bos_token=True"
+# Toy-model GPU test: verifies Info-Gain prefix/dual cache paths match Fast-dLLM
+# for both LLaDA and Dream, including past_key_values and replace_position use.
+python scripts/tests/test_infogain_fastdllm_cache_gpu.py
 ```
 
-或使用脚本：
+For real checkpoint inference, use `test_infogain_real_inference.py`. It loads an
+actual LLaDA or Dream checkpoint, decodes a simple arithmetic prompt, and fails if
+the decoded answer is empty, still contains a mask token, or does not match the
+expected answer regex.
+
+```shell
+python scripts/tests/test_infogain_real_inference.py \
+    --pipeline llada \
+    --model_name_or_path /path/to/LLaDA-8B-Instruct \
+    --modes none \
+    --expected_regex '\b(96|ninety[- ]?six)\b'
+
+python scripts/tests/test_infogain_real_inference.py \
+    --pipeline dream \
+    --model_name_or_path /path/to/Dream-v0-Instruct-7B \
+    --modes none \
+    --expected_regex '\b(96|ninety[- ]?six)\b'
+```
+
+Add `prefix dual` to `--modes` when validating the Fast-dLLM cache branches with
+the same real checkpoint:
+
+```shell
+python scripts/tests/test_infogain_real_inference.py \
+    --pipeline llada \
+    --model_name_or_path /path/to/LLaDA-8B-Instruct \
+    --modes none prefix dual
+```
+
+## Evaluation
+
+> Read [(optional) Evaluation setup](/README.md#optional-evaluation-setup) before running evaluation.
+
+For example, to evaluate [LLaDA-8B-Instruct](https://huggingface.co/GSAI-ML/LLaDA-8B-Instruct) or [Dream-v0-Instruct-7B](https://huggingface.co/Dream-org/Dream-v0-Instruct-7B) on [GSM8K](https://huggingface.co/datasets/openai/gsm8k) with 4 GPUs, run:
+
+```shell
+# Pass Info-Gain options via model_args (use_cache=none, threshold, candidate_number, position_temperature, variant, etc.).
+accelerate launch --num_processes 4 \
+    dllm/pipelines/infogain/llada/eval.py \
+    --tasks "gsm8k" \
+    --num_fewshot 5 \
+    --model "infogain_llada" \
+    --apply_chat_template \
+    --model_args "pretrained=GSAI-ML/LLaDA-8B-Instruct,use_cache=none,threshold=0.8,candidate_number=8,position_temperature=0.2,variant=info_gain,max_new_tokens=256,steps=256,block_size=32,suppress_tokens=[],begin_suppress_tokens=[]"
+
+accelerate launch --num_processes 4 \
+    dllm/pipelines/infogain/dream/eval.py \
+    --tasks "gsm8k" \
+    --num_fewshot 5 \
+    --model "infogain_dream" \
+    --apply_chat_template \
+    --model_args "pretrained=Dream-org/Dream-v0-Instruct-7B,use_cache=none,alg=info_gain,threshold=0.8,candidate_number=8,position_temperature=0.2,info_gain_variant=info_gain,temperature=0.0,top_p=0.9,max_new_tokens=256,steps=256,block_size=32,dtype=bfloat16,add_bos_token=True"
+```
+
+To run the bundled scripts (they launch **standard** `llada` / `dream` evals plus **Info-Gain**; the LLaDA script also runs **Info-Gain + Fast-dLLM prefix cache** on GSM8K), use:
 
 ```shell
 bash examples/infogain/llada/eval.sh --model_name_or_path "GSAI-ML/LLaDA-8B-Instruct" --instruct True --num_gpu 1
 bash examples/infogain/dream/eval.sh --model_name_or_path "Dream-org/Dream-v0-Base-7B" --instruct False --num_gpu 1
 ```
 
-## 说明
+Optional flags for `eval.sh`: `--max_new_tokens`, `--threshold`, `--candidate_number` (LLaDA and Dream); `--block_size` (Dream only).
 
-- LLaDA 在 **`use_cache=None`** 时采用 Info-Gain 单步解码；**当前实现要求 batch size 为 1**。多卡评测时请保持每进程 batch 为 1（与常见 `lm-eval` 设置一致）。
-- 设置 `use_cache` 为 `prefix` 或 `dual` 时，LLaDA 采样器继承 Fast-dLLM 的 KV 与并行解码逻辑，便于与 Fast-dLLM 基线对比。
-- Dream 的 **`alg=info_gain`** 仅在 **`use_cache=None`** 时生效，且 **batch size 须为 1**。
+## Notes
+
+- **Batch size**: Info-Gain decoding for both LLaDA (`use_cache=none`) and Dream (`alg=info_gain` with `use_cache=none`) currently requires **batch size 1**. Keep per-process batch at 1 under multi-GPU `lm-eval` / `accelerate` runs.
+- **LLaDA**: `use_cache=prefix` or `dual` uses the Fast-dLLM-style KV and parallel decode path inside the Info-Gain pipeline module (not the inner Info-Gain objective), useful for comparing against Fast-dLLM.
+- **Dream**: `alg=info_gain` is only active when **`use_cache=none`**; other settings follow the Dream sampler’s Fast-dLLM-compatible branches.

--- a/examples/infogain/dream/eval.sh
+++ b/examples/infogain/dream/eval.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Info-Gain Dream evaluation (mirrors examples/fastdllm/dream/eval.sh, adds alg=info_gain).
+
+export PYTHONPATH=.:$PYTHONPATH
+export HF_ALLOW_CODE_EVAL=1
+export HF_DATASETS_TRUST_REMOTE_CODE=True
+export TORCH_NCCL_ASYNC_ERROR_HANDLING=1
+export NCCL_DEBUG=warn
+export TORCH_DISTRIBUTED_DEBUG=DETAIL
+
+model_name_or_path="Dream-org/Dream-v0-Base-7B"
+instruct=False
+num_gpu=1
+max_new_tokens=256
+block_size=32
+threshold="0.8"
+candidate_number=8
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --model_name_or_path) model_name_or_path="$2"; shift 2 ;;
+    --instruct) instruct="$2"; shift 2 ;;
+    --num_gpu) num_gpu="$2"; shift 2 ;;
+    --max_new_tokens) max_new_tokens="$2"; shift 2 ;;
+    --block_size) block_size="$2"; shift 2 ;;
+    --threshold) threshold="$2"; shift 2 ;;
+    --candidate_number) candidate_number="$2"; shift 2 ;;
+    *) echo "Error: Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
+if [ "$instruct" = "True" ]; then
+    echo ">>> Running in INSTRUCT mode"
+    dream_args="--model dream --apply_chat_template"
+    infogain_args="--model infogain_dream --apply_chat_template"
+else
+    echo ">>> Running in BASE mode"
+    dream_args="--model dream"
+    infogain_args="--model infogain_dream"
+fi
+
+BASE_DREAM="pretrained=${model_name_or_path},max_new_tokens=${max_new_tokens},steps=${max_new_tokens},alg=entropy,dtype=bfloat16,add_bos_token=True"
+
+IG_DREAM="pretrained=${model_name_or_path},use_cache=none,max_new_tokens=${max_new_tokens},steps=${max_new_tokens},block_size=${block_size},alg=info_gain,threshold=${threshold},candidate_number=${candidate_number},position_temperature=0.2,info_gain_variant=info_gain,temperature=0.0,top_p=0.9,dtype=bfloat16,add_bos_token=True"
+
+accelerate launch --num_processes "${num_gpu}" dllm/pipelines/dream/eval.py \
+    --tasks gsm8k --num_fewshot 5 ${dream_args} \
+    --model_args "${BASE_DREAM}"
+
+accelerate launch --num_processes "${num_gpu}" dllm/pipelines/infogain/dream/eval.py \
+    --tasks gsm8k --num_fewshot 5 ${infogain_args} \
+    --model_args "${IG_DREAM}"

--- a/examples/infogain/dream/sample.py
+++ b/examples/infogain/dream/sample.py
@@ -1,0 +1,91 @@
+"""
+python -u examples/infogain/dream/sample.py --model_name_or_path "Dream-org/Dream-v0-Instruct-7B"
+"""
+
+import time
+from dataclasses import dataclass
+
+import transformers
+
+import dllm
+
+
+@dataclass
+class ScriptArguments:
+    model_name_or_path: str = "Dream-org/Dream-v0-Instruct-7B"
+    seed: int = 42
+    visualize: bool = True
+
+    def __post_init__(self):
+        self.model_name_or_path = dllm.utils.resolve_with_base_env(
+            self.model_name_or_path, "BASE_MODELS_DIR"
+        )
+
+
+@dataclass
+class SamplerConfig(dllm.pipelines.infogain.dream.InfoGainDreamSamplerConfig):
+    steps: int = 256
+    max_new_tokens: int = 256
+    block_size: int = 32
+    temperature: float = 0.0
+    top_p: float = None
+    top_k: int = None
+    alg: str = "info_gain"
+    threshold: float = 0.8
+    use_cache: str = "none"
+    candidate_number: int = 8
+    position_temperature: float = 0.2
+    info_gain_variant: str = "info_gain"
+
+
+parser = transformers.HfArgumentParser((ScriptArguments, SamplerConfig))
+script_args, sampler_config = parser.parse_args_into_dataclasses()
+transformers.set_seed(script_args.seed)
+dream_cfg = dllm.pipelines.infogain.dream.InfoGainDreamConfig.from_pretrained(
+    script_args.model_name_or_path
+)
+
+model = dllm.utils.get_model(model_args=script_args, config=dream_cfg).eval()
+tokenizer = dllm.utils.get_tokenizer(model_args=script_args)
+sampler = dllm.pipelines.infogain.dream.InfoGainDreamSampler(model=model, tokenizer=tokenizer)
+terminal_visualizer = dllm.utils.TerminalVisualizer(tokenizer=tokenizer)
+
+print("\n" + "=" * 80)
+print("TEST: infogain dream.sample()".center(80))
+print("=" * 80)
+
+messages = [
+    [{"role": "user", "content": "Lily runs 12 km/h for 4 hours. How far in 8 hours?"}],
+]
+
+inputs = tokenizer.apply_chat_template(
+    messages,
+    add_generation_prompt=True,
+    tokenize=True,
+)
+
+start = time.time()
+outputs = sampler.sample(inputs, sampler_config, return_dict=True)
+end = time.time()
+sequences = dllm.utils.sample_trim(tokenizer, outputs.sequences.tolist(), inputs)
+
+for i, s in enumerate(sequences):
+    print("\n" + "-" * 80)
+    print(f"[Case {i}]")
+    print("-" * 80)
+    print(s.strip() if s.strip() else "<empty>")
+print("\n" + "=" * 80 + "\n")
+
+if script_args.visualize:
+    terminal_visualizer.visualize(outputs.histories, rich=True)
+
+print(
+    f"Config: use_cache={sampler_config.use_cache}, alg={sampler_config.alg}, "
+    f"threshold={sampler_config.threshold}, candidate_number={sampler_config.candidate_number}"
+)
+print(
+    f"Total NFE:{len(outputs.histories) - 1}. Time taken for sampling: {end - start:.2f} seconds"
+)
+print(
+    f"Token speed: {(len(outputs.sequences[0])-len(inputs[0]))*1.0/(end - start):.2f} tokens/s"
+)

--- a/examples/infogain/llada/eval.sh
+++ b/examples/infogain/llada/eval.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Info-Gain LLaDA evaluation (mirrors examples/fastdllm/llada/eval.sh structure).
+
+export PYTHONPATH=.:$PYTHONPATH
+export HF_ALLOW_CODE_EVAL=1
+export HF_DATASETS_TRUST_REMOTE_CODE=True
+export TORCH_NCCL_ASYNC_ERROR_HANDLING=1
+export NCCL_DEBUG=warn
+export TORCH_DISTRIBUTED_DEBUG=DETAIL
+
+model_name_or_path="GSAI-ML/LLaDA-8B-Instruct"
+instruct=True
+num_gpu=1
+max_new_tokens=256
+threshold="0.8"
+candidate_number=8
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --model_name_or_path) model_name_or_path="$2"; shift 2 ;;
+    --instruct) instruct="$2"; shift 2 ;;
+    --num_gpu) num_gpu="$2"; shift 2 ;;
+    --max_new_tokens) max_new_tokens="$2"; shift 2 ;;
+    --threshold) threshold="$2"; shift 2 ;;
+    --candidate_number) candidate_number="$2"; shift 2 ;;
+    *) echo "Error: Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
+if [ "$instruct" = "True" ]; then
+    echo ">>> Running in INSTRUCT mode"
+    llada_args="--model llada --apply_chat_template"
+    infogain_args="--model infogain_llada --apply_chat_template"
+else
+    echo ">>> Running in BASE mode"
+    llada_args="--model llada"
+    infogain_args="--model infogain_llada"
+fi
+
+IG_ARGS="pretrained=${model_name_or_path},use_cache=none,threshold=${threshold},candidate_number=${candidate_number},position_temperature=0.2,variant=info_gain,max_new_tokens=${max_new_tokens},steps=${max_new_tokens},block_size=32,suppress_tokens=[],begin_suppress_tokens=[]"
+
+# GSM8K — baseline vs Info-Gain (no KV cache)
+accelerate launch --num_processes "${num_gpu}" dllm/pipelines/llada/eval.py \
+    --tasks gsm8k --num_fewshot 5 ${llada_args} \
+    --model_args "pretrained=${model_name_or_path},max_new_tokens=${max_new_tokens},steps=${max_new_tokens},block_size=32,suppress_tokens=[],begin_suppress_tokens=[126081;126348]"
+
+accelerate launch --num_processes "${num_gpu}" dllm/pipelines/infogain/llada/eval.py \
+    --tasks gsm8k --num_fewshot 5 ${infogain_args} \
+    --model_args "${IG_ARGS}"
+
+# Info-Gain + Fast-dLLM prefix cache (KV path; not Info-Gain inner objective)
+accelerate launch --num_processes "${num_gpu}" dllm/pipelines/infogain/llada/eval.py \
+    --tasks gsm8k --num_fewshot 5 ${infogain_args} \
+    --model_args "pretrained=${model_name_or_path},use_cache=prefix,threshold=${threshold},max_new_tokens=${max_new_tokens},steps=${max_new_tokens},block_size=32,suppress_tokens=[],begin_suppress_tokens=[]"

--- a/examples/infogain/llada/sample.py
+++ b/examples/infogain/llada/sample.py
@@ -1,0 +1,90 @@
+"""
+python -u examples/infogain/llada/sample.py --model_name_or_path "GSAI-ML/LLaDA-8B-Instruct"
+"""
+
+import time
+from dataclasses import dataclass
+
+import transformers
+
+import dllm
+
+
+@dataclass
+class ScriptArguments:
+    model_name_or_path: str = "GSAI-ML/LLaDA-8B-Instruct"
+    seed: int = 42
+    visualize: bool = True
+
+    def __post_init__(self):
+        self.model_name_or_path = dllm.utils.resolve_with_base_env(
+            self.model_name_or_path, "BASE_MODELS_DIR"
+        )
+
+
+@dataclass
+class SamplerConfig(dllm.pipelines.infogain.llada.InfoGainLLaDASamplerConfig):
+    steps: int = 256
+    max_new_tokens: int = 256
+    block_size: int = 32
+    temperature: float = 0.0
+    remasking: str = "low_confidence"
+    use_cache: str = "none"
+    threshold: float = 0.8
+    candidate_number: int = 8
+    position_temperature: float = 0.2
+    variant: str = "info_gain"
+    begin_suppress_tokens: list[int] = None
+
+
+parser = transformers.HfArgumentParser((ScriptArguments, SamplerConfig))
+script_args, sampler_config = parser.parse_args_into_dataclasses()
+transformers.set_seed(script_args.seed)
+cfg = dllm.pipelines.infogain.llada.InfoGainLLaDAConfig.from_pretrained(
+    script_args.model_name_or_path
+)
+
+model = dllm.utils.get_model(model_args=script_args, config=cfg).eval()
+tokenizer = dllm.utils.get_tokenizer(model_args=script_args)
+sampler = dllm.pipelines.infogain.llada.InfoGainLLaDASampler(model=model, tokenizer=tokenizer)
+terminal_visualizer = dllm.utils.TerminalVisualizer(tokenizer=tokenizer)
+
+print("\n" + "=" * 80)
+print("TEST: infogain llada.sample()".center(80))
+print("=" * 80)
+
+messages = [
+    [{"role": "user", "content": "Lily runs 12 km/h for 4 hours. How far in 8 hours?"}],
+]
+
+inputs = tokenizer.apply_chat_template(
+    messages,
+    add_generation_prompt=True,
+    tokenize=True,
+)
+
+start = time.time()
+outputs = sampler.sample(inputs, config=sampler_config, return_dict=True)
+end = time.time()
+sequences = dllm.utils.sample_trim(tokenizer, outputs.sequences.tolist(), inputs)
+
+for i, s in enumerate(sequences):
+    print("\n" + "-" * 80)
+    print(f"[Case {i}]")
+    print("-" * 80)
+    print(s.strip() if s.strip() else "<empty>")
+print("\n" + "=" * 80 + "\n")
+
+if script_args.visualize:
+    terminal_visualizer.visualize(outputs.histories, rich=True)
+
+print(
+    f"Config: use_cache={sampler_config.use_cache}, threshold={sampler_config.threshold}, "
+    f"candidate_number={sampler_config.candidate_number}, variant={sampler_config.variant}"
+)
+print(
+    f"Total NFE:{len(outputs.histories) - 1}. Time taken for sampling: {end - start:.2f} seconds"
+)
+print(
+    f"Token speed: {(len(outputs.sequences[0])-len(inputs[0]))*1.0/(end - start):.2f} tokens/s"
+)

--- a/examples/llada/README.md
+++ b/examples/llada/README.md
@@ -213,6 +213,8 @@ bash examples/llada/eval.sh --model_name_or_path GSAI-ML/LLaDA-8B-Base --instruc
 
 For **Fast-dLLM** sampling and evaluation with LLaDA, see the [Fast-dLLM README](../fastdllm/README.md).
 
+For **Info-Gain** sampling and evaluation with LLaDA, see the [Info-Gain README](../infogain/README.md).
+
 ### Evaluation results
 
 > Results (Reproduced) are evaluated using our framework, while results (Official) come from the original [paper](https://arxiv.org/abs/2502.09992). All evaluation settings follow the configurations in the [LLaDA](https://github.com/ML-GSAI/LLaDA) repository, with minor adjustments. 

--- a/scripts/tests/test_infogain_fastdllm_cache_gpu.py
+++ b/scripts/tests/test_infogain_fastdllm_cache_gpu.py
@@ -1,3 +1,9 @@
+"""
+Run from the dllm repo root on a GPU node:
+
+    python scripts/tests/test_infogain_fastdllm_cache_gpu.py
+"""
+
 from __future__ import annotations
 
 import copy

--- a/scripts/tests/test_infogain_fastdllm_cache_gpu.py
+++ b/scripts/tests/test_infogain_fastdllm_cache_gpu.py
@@ -7,9 +7,15 @@ Run from the dllm repo root on a GPU node:
 from __future__ import annotations
 
 import copy
+import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 import torch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from dllm.pipelines.fastdllm.llada import FastdLLMLLaDASampler, FastdLLMLLaDASamplerConfig
 from dllm.pipelines.fastdllm.dream import FastdLLMDreamSampler, FastdLLMDreamSamplerConfig
@@ -119,7 +125,7 @@ def run_one_llada_mode(mode: str, device: torch.device) -> dict[str, object]:
     info_model = copy.deepcopy(base_model).to(device).eval()
 
     tokenizer = TinyTokenizer()
-    prompt = torch.tensor([[1, 5, 6, 7]], device=device)
+    prompt = torch.tensor([[1, 5, 6, 7], [1, 8, 9, 10]], device=device)
 
     common = dict(
         max_new_tokens=8,
@@ -160,7 +166,7 @@ def run_one_llada_mode(mode: str, device: torch.device) -> dict[str, object]:
         "info_calls": len(info_model.calls),
         "info_saw_past": info_saw_past,
         "info_saw_replace": info_saw_replace,
-        "tail": info_out.sequences[0, -8:].detach().cpu().tolist(),
+        "tail": info_out.sequences[:, -8:].detach().cpu().tolist(),
     }
 
 
@@ -171,7 +177,10 @@ def run_one_dream_mode(mode: str, device: torch.device) -> dict[str, object]:
     info_model = copy.deepcopy(base_model).to(device).eval()
 
     tokenizer = TinyTokenizer()
-    prompt = [torch.tensor([1, 5, 6, 7], device=device)]
+    prompt = [
+        torch.tensor([1, 5, 6, 7], device=device),
+        torch.tensor([1, 8, 9, 10], device=device),
+    ]
 
     common = dict(
         max_new_tokens=8,
@@ -215,7 +224,7 @@ def run_one_dream_mode(mode: str, device: torch.device) -> dict[str, object]:
         "info_calls": len(info_model.calls),
         "info_saw_past": info_saw_past,
         "info_saw_replace": info_saw_replace,
-        "tail": info_out.sequences[0, -8:].detach().cpu().tolist(),
+        "tail": info_out.sequences[:, -8:].detach().cpu().tolist(),
     }
 
 

--- a/scripts/tests/test_infogain_fastdllm_cache_gpu.py
+++ b/scripts/tests/test_infogain_fastdllm_cache_gpu.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import copy
+from types import SimpleNamespace
+
+import torch
+
+from dllm.pipelines.fastdllm.llada import FastdLLMLLaDASampler, FastdLLMLLaDASamplerConfig
+from dllm.pipelines.fastdllm.dream import FastdLLMDreamSampler, FastdLLMDreamSamplerConfig
+from dllm.pipelines.infogain.llada import InfoGainLLaDASampler, InfoGainLLaDASamplerConfig
+from dllm.pipelines.infogain.dream import InfoGainDreamSampler, InfoGainDreamSamplerConfig
+
+
+class TinyTokenizer:
+    mask_token_id = 0
+    bos_token_id = 1
+    eos_token_id = 2
+
+
+class CacheAwareTinyModel(torch.nn.Module):
+    """Small deterministic model that exposes the cache contract Fast-dLLM needs."""
+
+    def __init__(self, vocab_size: int = 64, hidden_size: int = 32):
+        super().__init__()
+        self.embedding = torch.nn.Embedding(vocab_size, hidden_size)
+        self.proj = torch.nn.Linear(hidden_size, vocab_size, bias=False)
+        self.calls: list[dict[str, object]] = []
+
+    @property
+    def device(self) -> torch.device:
+        return next(self.parameters()).device
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        past_key_values=None,
+        use_cache: bool = False,
+        replace_position: torch.Tensor | None = None,
+        **_: object,
+    ):
+        self.calls.append(
+            {
+                "seq_len": int(input_ids.shape[1]),
+                "use_cache": bool(use_cache),
+                "has_past": past_key_values is not None,
+                "has_replace": replace_position is not None,
+                "replace_count": int(replace_position.sum().item()) if replace_position is not None else 0,
+            }
+        )
+
+        hidden = torch.tanh(self.embedding(input_ids))
+        logits = self.proj(hidden)
+        position_bias = torch.arange(input_ids.shape[1], device=input_ids.device, dtype=logits.dtype)
+        logits = logits + position_bias.view(1, -1, 1) * 0.01
+        logits[..., TinyTokenizer.mask_token_id] = -30.0
+
+        pkv = None
+        if use_cache:
+            batch, seq_len = input_ids.shape
+            old_len = 0 if past_key_values is None else int(past_key_values[0][0].shape[2])
+            total_len = old_len + seq_len
+            dummy = torch.zeros(batch, 1, total_len, 1, device=input_ids.device, dtype=logits.dtype)
+            pkv = [(dummy, dummy)]
+
+        return SimpleNamespace(logits=logits, past_key_values=pkv)
+
+
+class CacheAwareTinyDreamModel(CacheAwareTinyModel):
+    """Dream cache tensors use [batch, seq, dim] instead of LLaDA's [batch, heads, seq, dim]."""
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        past_key_values=None,
+        use_cache: bool = False,
+        replace_position: torch.Tensor | None = None,
+        **_: object,
+    ):
+        self.calls.append(
+            {
+                "seq_len": int(input_ids.shape[1]),
+                "use_cache": bool(use_cache),
+                "has_past": past_key_values is not None,
+                "has_replace": replace_position is not None,
+                "replace_count": int(replace_position.sum().item()) if replace_position is not None else 0,
+            }
+        )
+
+        hidden = torch.tanh(self.embedding(input_ids))
+        logits = self.proj(hidden)
+        position_bias = torch.arange(input_ids.shape[1], device=input_ids.device, dtype=logits.dtype)
+        logits = logits + position_bias.view(1, -1, 1) * 0.01
+        logits[..., TinyTokenizer.mask_token_id] = -30.0
+
+        pkv = None
+        if use_cache:
+            batch, seq_len = input_ids.shape
+            old_len = 0 if past_key_values is None else int(past_key_values[0][0].shape[1])
+            total_len = old_len + seq_len
+            dummy = torch.zeros(batch, total_len, 1, device=input_ids.device, dtype=logits.dtype)
+            pkv = [(dummy, dummy)]
+
+        return SimpleNamespace(logits=logits, past_key_values=pkv)
+
+
+def run_one_llada_mode(mode: str, device: torch.device) -> dict[str, object]:
+    torch.manual_seed(7)
+    base_model = CacheAwareTinyModel()
+    fast_model = copy.deepcopy(base_model).to(device).eval()
+    info_model = copy.deepcopy(base_model).to(device).eval()
+
+    tokenizer = TinyTokenizer()
+    prompt = torch.tensor([[1, 5, 6, 7]], device=device)
+
+    common = dict(
+        max_new_tokens=8,
+        steps=8,
+        block_size=4,
+        temperature=0.0,
+        remasking="low_confidence",
+        threshold=None,
+        use_cache=mode,
+        return_dict=True,
+    )
+    fast_cfg = FastdLLMLLaDASamplerConfig(**common)
+    info_cfg = InfoGainLLaDASamplerConfig(**common)
+
+    with torch.no_grad():
+        fast_out = FastdLLMLLaDASampler(fast_model, tokenizer).sample(prompt, config=fast_cfg)
+        info_out = InfoGainLLaDASampler(info_model, tokenizer).sample(prompt, config=info_cfg)
+
+    same = torch.equal(fast_out.sequences, info_out.sequences)
+    if not same:
+        raise AssertionError(f"{mode}: Info-Gain cache delegation changed Fast-dLLM output")
+    if torch.any(info_out.sequences[:, prompt.shape[1] :] == tokenizer.mask_token_id):
+        raise AssertionError(f"{mode}: generated suffix still contains mask tokens")
+
+    info_saw_past = any(call["has_past"] for call in info_model.calls)
+    info_saw_replace = any(call["has_replace"] for call in info_model.calls)
+    if not info_saw_past:
+        raise AssertionError(f"{mode}: cache path never reused past_key_values")
+    if mode == "dual" and not info_saw_replace:
+        raise AssertionError("dual: cache path never passed replace_position")
+    if mode == "prefix" and info_saw_replace:
+        raise AssertionError("prefix: replace_position should not be used")
+
+    return {
+        "mode": mode,
+        "same": same,
+        "fast_calls": len(fast_model.calls),
+        "info_calls": len(info_model.calls),
+        "info_saw_past": info_saw_past,
+        "info_saw_replace": info_saw_replace,
+        "tail": info_out.sequences[0, -8:].detach().cpu().tolist(),
+    }
+
+
+def run_one_dream_mode(mode: str, device: torch.device) -> dict[str, object]:
+    torch.manual_seed(11)
+    base_model = CacheAwareTinyDreamModel()
+    fast_model = copy.deepcopy(base_model).to(device).eval()
+    info_model = copy.deepcopy(base_model).to(device).eval()
+
+    tokenizer = TinyTokenizer()
+    prompt = [torch.tensor([1, 5, 6, 7], device=device)]
+
+    common = dict(
+        max_new_tokens=8,
+        steps=8,
+        block_size=4,
+        alg="maskgit_plus",
+        temperature=0.0,
+        top_p=1.0,
+        top_k=None,
+        threshold=None,
+        right_shift_logits=False,
+        use_cache=mode,
+        return_dict=True,
+    )
+    fast_cfg = FastdLLMDreamSamplerConfig(**common)
+    info_cfg = InfoGainDreamSamplerConfig(**common)
+
+    with torch.no_grad():
+        fast_out = FastdLLMDreamSampler(fast_model, tokenizer).sample(prompt, config=fast_cfg)
+        info_out = InfoGainDreamSampler(info_model, tokenizer).sample(prompt, config=info_cfg)
+
+    same = torch.equal(fast_out.sequences, info_out.sequences)
+    if not same:
+        raise AssertionError(f"dream/{mode}: Info-Gain cache path changed Fast-dLLM output")
+    if torch.any(info_out.sequences[:, -8:] == tokenizer.mask_token_id):
+        raise AssertionError(f"dream/{mode}: generated suffix still contains mask tokens")
+
+    info_saw_past = any(call["has_past"] for call in info_model.calls)
+    info_saw_replace = any(call["has_replace"] for call in info_model.calls)
+    if not info_saw_past:
+        raise AssertionError(f"dream/{mode}: cache path never reused past_key_values")
+    if mode == "dual" and not info_saw_replace:
+        raise AssertionError("dream/dual: cache path never passed replace_position")
+    if mode == "prefix" and info_saw_replace:
+        raise AssertionError("dream/prefix: replace_position should not be used")
+
+    return {
+        "mode": f"dream/{mode}",
+        "same": same,
+        "fast_calls": len(fast_model.calls),
+        "info_calls": len(info_model.calls),
+        "info_saw_past": info_saw_past,
+        "info_saw_replace": info_saw_replace,
+        "tail": info_out.sequences[0, -8:].detach().cpu().tolist(),
+    }
+
+
+def main() -> None:
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required for this GPU cache smoke test")
+    device = torch.device("cuda")
+    print("torch", torch.__version__, torch.cuda.get_device_name(0))
+    for mode in ("prefix", "dual"):
+        result = run_one_llada_mode(mode, device)
+        print(
+            "mode=llada/{mode} same={same} fast_calls={fast_calls} info_calls={info_calls} "
+            "info_saw_past={info_saw_past} info_saw_replace={info_saw_replace} tail={tail}".format(**result)
+        )
+    for mode in ("prefix", "dual"):
+        result = run_one_dream_mode(mode, device)
+        print(
+            "mode={mode} same={same} fast_calls={fast_calls} info_calls={info_calls} "
+            "info_saw_past={info_saw_past} info_saw_replace={info_saw_replace} tail={tail}".format(**result)
+        )
+    print("INFOGAIN_FASTDLLM_CACHE_GPU_SMOKE=PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_infogain_gpu_smoke.py
+++ b/scripts/tests/test_infogain_gpu_smoke.py
@@ -1,0 +1,148 @@
+"""
+Run from the dllm repo root on a GPU node:
+
+    python scripts/tests/test_infogain_gpu_smoke.py
+
+This smoke test avoids external model downloads. It verifies that the
+Info-Gain LLaDA sampler runs end-to-end on CUDA and that candidate scoring is
+batched into one model forward instead of N sequential forwards.
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import torch
+
+from dllm.pipelines.infogain import info_gain_ops as ig
+from dllm.pipelines.infogain.llada import InfoGainLLaDASampler, InfoGainLLaDASamplerConfig
+
+
+class TinyTokenizer:
+    mask_token_id = 0
+    bos_token_id = 1
+    eos_token_id = 2
+
+
+class TinyMaskedModel(torch.nn.Module):
+    def __init__(self, vocab_size: int = 64, hidden_size: int = 256):
+        super().__init__()
+        self.embedding = torch.nn.Embedding(vocab_size, hidden_size)
+        self.mix = torch.nn.Sequential(
+            torch.nn.Linear(hidden_size, hidden_size),
+            torch.nn.GELU(),
+            torch.nn.Linear(hidden_size, hidden_size),
+            torch.nn.GELU(),
+        )
+        self.lm_head = torch.nn.Linear(hidden_size, vocab_size, bias=False)
+
+    @property
+    def device(self):
+        return next(self.parameters()).device
+
+    def forward(self, input_ids, attention_mask=None):
+        h = self.embedding(input_ids)
+        # Non-causal context mixing: every position can depend on the current canvas.
+        context = h.mean(dim=1, keepdim=True)
+        h = self.mix(h + context)
+        logits = self.lm_head(h)
+        logits[..., TinyTokenizer.mask_token_id] = -30.0
+        return SimpleNamespace(logits=logits)
+
+
+@torch.no_grad()
+def benchmark_candidate_scoring(device: torch.device) -> tuple[float, float, float]:
+    torch.manual_seed(0)
+    model = TinyMaskedModel(vocab_size=128, hidden_size=768).to(device).eval()
+    bsz, seqlen, n_candidates = 1, 256, 16
+    x = torch.randint(3, 128, (bsz, seqlen), device=device)
+    x[:, 64:] = TinyTokenizer.mask_token_id
+    mask_allowed = x == TinyTokenizer.mask_token_id
+
+    logits = model(x).logits
+    actions, x0s, _, _, _ = ig.generate_candidates(
+        logits=logits,
+        x=x,
+        mask_allowed=mask_allowed,
+        block_start=64,
+        block_end=128,
+        k=1,
+        n_candidates=n_candidates,
+        token_temp=0.0,
+        pos_temp=0.2,
+    )
+    assert actions is not None and len(actions) > 1
+
+    x_batch = x.expand(len(actions), -1).clone()
+    for i, (act, x0) in enumerate(zip(actions, x0s)):
+        x_batch[i, act] = x0[0, act]
+
+    for _ in range(5):
+        model(x_batch).logits
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(30):
+        model(x_batch).logits
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+    batched = time.perf_counter() - t0
+
+    for _ in range(5):
+        for xb in x_batch:
+            model(xb.unsqueeze(0)).logits
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(30):
+        for xb in x_batch:
+            model(xb.unsqueeze(0)).logits
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+    sequential = time.perf_counter() - t0
+
+    return batched, sequential, sequential / batched
+
+
+@torch.no_grad()
+def smoke_decode(device: torch.device) -> torch.Tensor:
+    torch.manual_seed(123)
+    model = TinyMaskedModel().to(device).eval()
+    sampler = InfoGainLLaDASampler(model=model, tokenizer=TinyTokenizer())
+    cfg = InfoGainLLaDASamplerConfig(
+        return_dict=True,
+        max_new_tokens=16,
+        steps=16,
+        block_size=8,
+        use_cache=None,
+        threshold=0.0,
+        candidate_number=8,
+        position_temperature=0.2,
+        variant="info_gain",
+    )
+    prompt = torch.tensor([[1, 7, 8, 9]], device=device)
+    out = sampler.sample(prompt, config=cfg)
+    assert out.sequences.device.type == device.type
+    assert out.sequences.shape == (1, 20)
+    assert not (out.sequences == TinyTokenizer.mask_token_id).any()
+    assert len(out.histories) >= 2
+    return out.sequences
+
+
+def main() -> None:
+    assert torch.cuda.is_available(), "This test must run on a real GPU node."
+    device = torch.device("cuda")
+    seq = smoke_decode(device)
+    batched, sequential, speedup = benchmark_candidate_scoring(device)
+    print("INFOGAIN_GPU_SMOKE=PASS")
+    print(f"device={torch.cuda.get_device_name(0)}")
+    print(f"decoded_shape={tuple(seq.shape)} decoded_tail={seq[0, -8:].tolist()}")
+    print(f"batched_candidate_seconds={batched:.4f}")
+    print(f"sequential_candidate_seconds={sequential:.4f}")
+    print(f"candidate_batch_speedup={speedup:.2f}x")
+    assert speedup > 1.15, f"Expected batched candidate scoring speedup, got {speedup:.2f}x"
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_infogain_gpu_smoke.py
+++ b/scripts/tests/test_infogain_gpu_smoke.py
@@ -10,13 +10,26 @@ batched into one model forward instead of N sequential forwards.
 
 from __future__ import annotations
 
+import sys
 import time
+from pathlib import Path
 from types import SimpleNamespace
 
 import torch
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from dllm.pipelines.infogain import info_gain_ops as ig
-from dllm.pipelines.infogain.llada import InfoGainLLaDASampler, InfoGainLLaDASamplerConfig
+from dllm.pipelines.infogain.dream import (
+    InfoGainDreamSampler,
+    InfoGainDreamSamplerConfig,
+)
+from dllm.pipelines.infogain.llada import (
+    InfoGainLLaDASampler,
+    InfoGainLLaDASamplerConfig,
+)
 
 
 class TinyTokenizer:
@@ -41,7 +54,7 @@ class TinyMaskedModel(torch.nn.Module):
     def device(self):
         return next(self.parameters()).device
 
-    def forward(self, input_ids, attention_mask=None):
+    def forward(self, input_ids, attention_mask=None, position_ids=None, **_):
         h = self.embedding(input_ids)
         # Non-causal context mixing: every position can depend on the current canvas.
         context = h.mean(dim=1, keepdim=True)
@@ -106,7 +119,7 @@ def benchmark_candidate_scoring(device: torch.device) -> tuple[float, float, flo
 
 
 @torch.no_grad()
-def smoke_decode(device: torch.device) -> torch.Tensor:
+def smoke_decode_llada_batch(device: torch.device) -> torch.Tensor:
     torch.manual_seed(123)
     model = TinyMaskedModel().to(device).eval()
     sampler = InfoGainLLaDASampler(model=model, tokenizer=TinyTokenizer())
@@ -121,11 +134,44 @@ def smoke_decode(device: torch.device) -> torch.Tensor:
         position_temperature=0.2,
         variant="info_gain",
     )
-    prompt = torch.tensor([[1, 7, 8, 9]], device=device)
+    prompt = torch.tensor([[1, 7, 8, 9], [1, 4, 5, 6]], device=device)
     out = sampler.sample(prompt, config=cfg)
     assert out.sequences.device.type == device.type
-    assert out.sequences.shape == (1, 20)
+    assert out.sequences.shape == (2, 20)
     assert not (out.sequences == TinyTokenizer.mask_token_id).any()
+    assert len(out.histories) >= 2
+    return out.sequences
+
+
+@torch.no_grad()
+def smoke_decode_dream_batch(device: torch.device) -> torch.Tensor:
+    torch.manual_seed(456)
+    model = TinyMaskedModel().to(device).eval()
+    sampler = InfoGainDreamSampler(model=model, tokenizer=TinyTokenizer())
+    cfg = InfoGainDreamSamplerConfig(
+        return_dict=True,
+        max_new_tokens=8,
+        steps=8,
+        block_size=4,
+        use_cache=None,
+        alg="info_gain",
+        threshold=0.8,
+        temperature=0.0,
+        top_p=1.0,
+        top_k=None,
+        right_shift_logits=False,
+        candidate_number=4,
+        position_temperature=0.2,
+        info_gain_variant="info_gain",
+    )
+    prompts = [
+        torch.tensor([1, 7, 8], device=device),
+        torch.tensor([1, 4, 5, 6], device=device),
+    ]
+    out = sampler.sample(prompts, config=cfg)
+    assert out.sequences.device.type == device.type
+    assert out.sequences.shape == (2, 12)
+    assert not (out.sequences[:, -8:] == TinyTokenizer.mask_token_id).any()
     assert len(out.histories) >= 2
     return out.sequences
 
@@ -133,11 +179,25 @@ def smoke_decode(device: torch.device) -> torch.Tensor:
 def main() -> None:
     assert torch.cuda.is_available(), "This test must run on a real GPU node."
     device = torch.device("cuda")
-    seq = smoke_decode(device)
+    llada_seq = smoke_decode_llada_batch(device)
+    dream_seq = smoke_decode_dream_batch(device)
     batched, sequential, speedup = benchmark_candidate_scoring(device)
     print("INFOGAIN_GPU_SMOKE=PASS")
     print(f"device={torch.cuda.get_device_name(0)}")
-    print(f"decoded_shape={tuple(seq.shape)} decoded_tail={seq[0, -8:].tolist()}")
+    print(
+        "llada_batch_shape={} llada_tail0={} llada_tail1={}".format(
+            tuple(llada_seq.shape),
+            llada_seq[0, -8:].tolist(),
+            llada_seq[1, -8:].tolist(),
+        )
+    )
+    print(
+        "dream_batch_shape={} dream_tail0={} dream_tail1={}".format(
+            tuple(dream_seq.shape),
+            dream_seq[0, -8:].tolist(),
+            dream_seq[1, -8:].tolist(),
+        )
+    )
     print(f"batched_candidate_seconds={batched:.4f}")
     print(f"sequential_candidate_seconds={sequential:.4f}")
     print(f"candidate_batch_speedup={speedup:.2f}x")

--- a/scripts/tests/test_infogain_real_inference.py
+++ b/scripts/tests/test_infogain_real_inference.py
@@ -1,3 +1,9 @@
+"""
+Run from the dllm repo root on a GPU node, for example:
+
+    python scripts/tests/test_infogain_real_inference.py --pipeline llada --model_name_or_path /path/to/LLaDA-8B-Instruct
+"""
+
 from __future__ import annotations
 
 import argparse

--- a/scripts/tests/test_infogain_real_inference.py
+++ b/scripts/tests/test_infogain_real_inference.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import argparse
+import re
+import time
+from dataclasses import asdict
+
+import torch
+import transformers
+
+import dllm
+
+
+DEFAULT_PROMPT = "Lily runs 12 km/h for 4 hours. How far will Lily run in 8 hours?"
+DEFAULT_EXPECTED_RE = r"\b(96|ninety[- ]?six)\b"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Real-model Info-Gain inference correctness smoke test.")
+    parser.add_argument("--pipeline", choices=["llada", "dream"], required=True)
+    parser.add_argument("--model_name_or_path", required=True)
+    parser.add_argument("--prompt", default=DEFAULT_PROMPT)
+    parser.add_argument("--expected_regex", default=DEFAULT_EXPECTED_RE)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--max_new_tokens", type=int, default=64)
+    parser.add_argument("--steps", type=int, default=64)
+    parser.add_argument("--block_size", type=int, default=32)
+    parser.add_argument("--threshold", type=float, default=0.8)
+    parser.add_argument("--candidate_number", type=int, default=8)
+    parser.add_argument("--position_temperature", type=float, default=0.2)
+    parser.add_argument(
+        "--modes",
+        nargs="+",
+        default=["none"],
+        help="Cache modes to test. Use 'none' for the Info-Gain objective; prefix/dual test Fast-dLLM cache branches.",
+    )
+    parser.add_argument("--local_files_only", action="store_true")
+    return parser.parse_args()
+
+
+def make_inputs(tokenizer, prompt: str):
+    messages = [[{"role": "user", "content": prompt}]]
+    return tokenizer.apply_chat_template(
+        messages,
+        add_generation_prompt=True,
+        tokenize=True,
+    )
+
+
+def trim_outputs(tokenizer, outputs, inputs) -> list[str]:
+    trimmed = dllm.utils.sample_trim(tokenizer, outputs.sequences.tolist(), inputs)
+    return [text.strip() for text in trimmed]
+
+
+def check_generation(text: str, expected_regex: str, mode: str) -> None:
+    if not text:
+        raise AssertionError(f"{mode}: empty decoded output")
+    if re.search(r"<\|?mask\|?>|\[MASK\]", text, flags=re.IGNORECASE):
+        raise AssertionError(f"{mode}: decoded output still contains a mask token: {text!r}")
+    if not re.search(expected_regex, text, flags=re.IGNORECASE):
+        raise AssertionError(
+            f"{mode}: decoded output did not match {expected_regex!r}.\nOutput:\n{text}"
+        )
+
+
+def run_llada(args: argparse.Namespace) -> None:
+    cfg = dllm.pipelines.infogain.llada.InfoGainLLaDAConfig.from_pretrained(
+        args.model_name_or_path,
+        local_files_only=args.local_files_only,
+    )
+    model_args = argparse.Namespace(model_name_or_path=args.model_name_or_path)
+    model = dllm.utils.get_model(model_args=model_args, config=cfg).eval()
+    tokenizer = dllm.utils.get_tokenizer(model_args=model_args)
+    sampler = dllm.pipelines.infogain.llada.InfoGainLLaDASampler(model=model, tokenizer=tokenizer)
+    inputs = make_inputs(tokenizer, args.prompt)
+
+    for mode in args.modes:
+        sampler_config = dllm.pipelines.infogain.llada.InfoGainLLaDASamplerConfig(
+            steps=args.steps,
+            max_new_tokens=args.max_new_tokens,
+            block_size=args.block_size,
+            temperature=0.0,
+            remasking="low_confidence",
+            use_cache=mode,
+            threshold=args.threshold if mode == "none" else None,
+            candidate_number=args.candidate_number,
+            position_temperature=args.position_temperature,
+            variant="info_gain",
+            return_dict=True,
+        )
+        start = time.time()
+        with torch.no_grad():
+            outputs = sampler.sample(inputs, config=sampler_config, return_dict=True)
+        elapsed = time.time() - start
+        texts = trim_outputs(tokenizer, outputs, inputs)
+        for text in texts:
+            check_generation(text, args.expected_regex, f"llada/{mode}")
+        print(f"mode=llada/{mode} seconds={elapsed:.2f} config={asdict(sampler_config)}")
+        print("decoded=" + texts[0].replace("\n", "\\n"))
+
+
+def run_dream(args: argparse.Namespace) -> None:
+    cfg = dllm.pipelines.infogain.dream.InfoGainDreamConfig.from_pretrained(
+        args.model_name_or_path,
+        local_files_only=args.local_files_only,
+    )
+    model_args = argparse.Namespace(model_name_or_path=args.model_name_or_path)
+    model = dllm.utils.get_model(model_args=model_args, config=cfg).eval()
+    tokenizer = dllm.utils.get_tokenizer(model_args=model_args)
+    sampler = dllm.pipelines.infogain.dream.InfoGainDreamSampler(model=model, tokenizer=tokenizer)
+    inputs = make_inputs(tokenizer, args.prompt)
+
+    for mode in args.modes:
+        sampler_config = dllm.pipelines.infogain.dream.InfoGainDreamSamplerConfig(
+            steps=args.steps,
+            max_new_tokens=args.max_new_tokens,
+            block_size=args.block_size,
+            temperature=0.0,
+            top_p=None,
+            top_k=None,
+            alg="info_gain" if mode == "none" else "maskgit_plus",
+            threshold=args.threshold if mode == "none" else None,
+            use_cache=mode,
+            candidate_number=args.candidate_number,
+            position_temperature=args.position_temperature,
+            info_gain_variant="info_gain",
+            return_dict=True,
+        )
+        start = time.time()
+        with torch.no_grad():
+            outputs = sampler.sample(inputs, sampler_config, return_dict=True)
+        elapsed = time.time() - start
+        texts = trim_outputs(tokenizer, outputs, inputs)
+        for text in texts:
+            check_generation(text, args.expected_regex, f"dream/{mode}")
+        print(f"mode=dream/{mode} seconds={elapsed:.2f} config={asdict(sampler_config)}")
+        print("decoded=" + texts[0].replace("\n", "\\n"))
+
+
+def main() -> None:
+    args = parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required for real-model inference correctness")
+    transformers.set_seed(args.seed)
+    resolved = dllm.utils.resolve_with_base_env(args.model_name_or_path, "BASE_MODELS_DIR")
+    args.model_name_or_path = resolved
+    print("torch", torch.__version__, torch.cuda.get_device_name(0))
+    print("pipeline", args.pipeline)
+    print("model", args.model_name_or_path)
+    print("prompt", args.prompt)
+    print("expected_regex", args.expected_regex)
+    if args.pipeline == "llada":
+        run_llada(args)
+    else:
+        run_dream(args)
+    print("INFOGAIN_REAL_INFERENCE_CORRECTNESS=PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_infogain_safety.py
+++ b/scripts/tests/test_infogain_safety.py
@@ -1,0 +1,114 @@
+"""
+Run from the dllm repo root:
+
+    pytest scripts/tests/test_infogain_safety.py
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from dllm.pipelines.infogain import info_gain_ops as ig
+from dllm.pipelines.infogain.dream import (
+    InfoGainDreamSampler,
+    InfoGainDreamSamplerConfig,
+)
+from dllm.pipelines.infogain.llada import (
+    InfoGainLLaDASampler,
+    InfoGainLLaDASamplerConfig,
+)
+
+
+class TinyTokenizer:
+    mask_token_id = 0
+    bos_token_id = 1
+    eos_token_id = 2
+
+
+class TinyNoCacheModel(torch.nn.Module):
+    def __init__(self, vocab_size: int = 8):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.zeros(1))
+        self.vocab_size = vocab_size
+
+    @property
+    def device(self) -> torch.device:
+        return self.weight.device
+
+    def forward(self, input_ids, *_, **__):
+        logits = torch.zeros(
+            input_ids.shape[0],
+            input_ids.shape[1],
+            self.vocab_size,
+            device=input_ids.device,
+        )
+        logits[..., TinyTokenizer.mask_token_id] = -30.0
+        return SimpleNamespace(logits=logits, past_key_values=None)
+
+
+def test_resolve_generation_lengths_validates_bounds() -> None:
+    assert ig.resolve_generation_lengths(4, None, 3) == (4, 7)
+    assert ig.resolve_generation_lengths(4, 6, 3) == (3, 6)
+
+    with pytest.raises(ValueError, match="Either max_new_tokens or max_length"):
+        ig.resolve_generation_lengths(None, None, 3)
+    with pytest.raises(ValueError, match="max_new_tokens must be positive"):
+        ig.resolve_generation_lengths(0, None, 3)
+    with pytest.raises(ValueError, match="leave room"):
+        ig.resolve_generation_lengths(None, 3, 3)
+
+
+def test_llada_info_gain_rejects_batched_no_cache() -> None:
+    sampler = InfoGainLLaDASampler(model=TinyNoCacheModel(), tokenizer=TinyTokenizer())
+    cfg = InfoGainLLaDASamplerConfig(
+        max_new_tokens=2,
+        steps=2,
+        block_size=1,
+        use_cache=None,
+        threshold=0.0,
+    )
+
+    with pytest.raises(ValueError, match="batch size 1"):
+        sampler.sample(
+            [torch.tensor([1, 3]), torch.tensor([1, 4])],
+            config=cfg,
+        )
+
+
+def test_dream_info_gain_rejects_batched_no_cache() -> None:
+    sampler = InfoGainDreamSampler(model=TinyNoCacheModel(), tokenizer=TinyTokenizer())
+    cfg = InfoGainDreamSamplerConfig(
+        max_new_tokens=2,
+        steps=2,
+        block_size=1,
+        use_cache=None,
+        alg="info_gain",
+        threshold=0.8,
+    )
+
+    with pytest.raises(ValueError, match="batch size 1"):
+        sampler.sample(
+            [torch.tensor([1, 3]), torch.tensor([1, 4])],
+            config=cfg,
+        )
+
+
+def test_dream_cache_requires_model_to_return_past_key_values() -> None:
+    sampler = InfoGainDreamSampler(model=TinyNoCacheModel(), tokenizer=TinyTokenizer())
+    cfg = InfoGainDreamSamplerConfig(
+        max_new_tokens=2,
+        steps=2,
+        block_size=1,
+        use_cache="prefix",
+        alg="maskgit_plus",
+        temperature=0.0,
+        top_p=1.0,
+        top_k=None,
+        right_shift_logits=False,
+    )
+
+    with pytest.raises(RuntimeError, match="past_key_values"):
+        sampler.sample([torch.tensor([1, 3])], config=cfg)

--- a/scripts/tests/test_infogain_safety.py
+++ b/scripts/tests/test_infogain_safety.py
@@ -61,7 +61,7 @@ def test_resolve_generation_lengths_validates_bounds() -> None:
         ig.resolve_generation_lengths(None, 3, 3)
 
 
-def test_llada_info_gain_rejects_batched_no_cache() -> None:
+def test_llada_info_gain_supports_batched_no_cache() -> None:
     sampler = InfoGainLLaDASampler(model=TinyNoCacheModel(), tokenizer=TinyTokenizer())
     cfg = InfoGainLLaDASamplerConfig(
         max_new_tokens=2,
@@ -69,16 +69,20 @@ def test_llada_info_gain_rejects_batched_no_cache() -> None:
         block_size=1,
         use_cache=None,
         threshold=0.0,
+        return_dict=True,
     )
 
-    with pytest.raises(ValueError, match="batch size 1"):
-        sampler.sample(
-            [torch.tensor([1, 3]), torch.tensor([1, 4])],
-            config=cfg,
-        )
+    out = sampler.sample(
+        [torch.tensor([1, 3]), torch.tensor([1, 4])],
+        config=cfg,
+    )
+
+    assert out.sequences.shape == (2, 4)
+    assert not (out.sequences[:, 2:] == TinyTokenizer.mask_token_id).any()
+    assert len(out.histories) >= 2
 
 
-def test_dream_info_gain_rejects_batched_no_cache() -> None:
+def test_dream_info_gain_supports_batched_no_cache() -> None:
     sampler = InfoGainDreamSampler(model=TinyNoCacheModel(), tokenizer=TinyTokenizer())
     cfg = InfoGainDreamSamplerConfig(
         max_new_tokens=2,
@@ -87,13 +91,42 @@ def test_dream_info_gain_rejects_batched_no_cache() -> None:
         use_cache=None,
         alg="info_gain",
         threshold=0.8,
+        return_dict=True,
     )
 
-    with pytest.raises(ValueError, match="batch size 1"):
-        sampler.sample(
-            [torch.tensor([1, 3]), torch.tensor([1, 4])],
-            config=cfg,
-        )
+    out = sampler.sample(
+        [torch.tensor([1, 3]), torch.tensor([1, 4])],
+        config=cfg,
+    )
+
+    assert out.sequences.shape == (2, 4)
+    assert not (out.sequences[:, -2:] == TinyTokenizer.mask_token_id).any()
+    assert len(out.histories) >= 2
+
+
+def test_dream_confidence_threshold_supports_batched_no_cache() -> None:
+    sampler = InfoGainDreamSampler(model=TinyNoCacheModel(), tokenizer=TinyTokenizer())
+    cfg = InfoGainDreamSamplerConfig(
+        max_new_tokens=3,
+        steps=3,
+        block_size=1,
+        use_cache=None,
+        alg="confidence_threshold",
+        threshold=0.8,
+        temperature=0.0,
+        top_p=1.0,
+        top_k=None,
+        right_shift_logits=False,
+        return_dict=True,
+    )
+
+    out = sampler.sample(
+        [torch.tensor([1, 3]), torch.tensor([1, 4])],
+        config=cfg,
+    )
+
+    assert out.sequences.shape == (2, 5)
+    assert not (out.sequences[:, -3:] == TinyTokenizer.mask_token_id).any()
 
 
 def test_dream_cache_requires_model_to_return_past_key_values() -> None:

--- a/scripts/tests/test_infogain_safety.py
+++ b/scripts/tests/test_infogain_safety.py
@@ -61,6 +61,48 @@ def test_resolve_generation_lengths_validates_bounds() -> None:
         ig.resolve_generation_lengths(None, 3, 3)
 
 
+def test_info_gain_cost_reduction_supports_entropy_star() -> None:
+    logits = torch.zeros(1, 4, 4)
+    next_logits = torch.zeros(2, 4, 4)
+    x_batch = torch.ones(2, 4, dtype=torch.long)
+    actions = [torch.tensor([0, 1]), torch.tensor([2])]
+    token_entropy = torch.log(torch.tensor(4.0))
+
+    sum_cost, _, _ = ig.score_candidates(
+        logits,
+        next_logits,
+        x_batch,
+        actions,
+        mask_id=0,
+        cost_reduction="sum",
+        future_weight=0.0,
+    )
+    mean_cost, _, weighted_j = ig.score_candidates(
+        logits,
+        next_logits,
+        x_batch,
+        actions,
+        mask_id=0,
+        cost_reduction="entropy*",
+        cost_weight=2.0,
+        future_weight=0.0,
+    )
+
+    assert torch.allclose(sum_cost, torch.stack([2 * token_entropy, token_entropy]))
+    assert torch.allclose(mean_cost, torch.stack([token_entropy, token_entropy]))
+    assert torch.allclose(weighted_j, -2.0 * mean_cost)
+
+    with pytest.raises(ValueError, match="cost reduction"):
+        ig.score_candidates(
+            logits,
+            next_logits,
+            x_batch,
+            actions,
+            mask_id=0,
+            cost_reduction="bad",
+        )
+
+
 def test_llada_info_gain_supports_batched_no_cache() -> None:
     sampler = InfoGainLLaDASampler(model=TinyNoCacheModel(), tokenizer=TinyTokenizer())
     cfg = InfoGainLLaDASamplerConfig(


### PR DESCRIPTION
## Summary
- Add and document Info-Gain inference/evaluation entry points for LLaDA and Dream.
- Harden pipeline/tokenizer imports so optional pipeline dependencies do not block Info-Gain usage on older Transformers environments.
- Add GPU smoke tests for Info-Gain no-cache decoding, Fast-dLLM prefix/dual cache delegation, and real-checkpoint inference correctness.

## Validation
- Real H200 + `GSAI-ML/LLaDA-8B-Instruct` correctness:
  - `llada/none`: decoded `96`, 1.86s
  - `llada/prefix`: decoded `96`, 1.40s
  - `llada/dual`: decoded `96`, 1.64s
  - `INFOGAIN_REAL_INFERENCE_CORRECTNESS=PASS`
- H200 cache parity smoke:
  - LLaDA prefix/dual match Fast-dLLM outputs and exercise `past_key_values` / `replace_position`.
  - Dream prefix/dual match Fast-dLLM outputs and exercise `past_key_values` / `replace_position`.
  - `INFOGAIN_FASTDLLM_CACHE_GPU_SMOKE=PASS`
- H200 Info-Gain GPU smoke:
  - `INFOGAIN_GPU_SMOKE=PASS`
  - candidate batch speedup: `3.87x`
- `py_compile` on changed modules and new smoke tests.